### PR TITLE
Feature/delivery

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Check Out Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
         run: echo ${{ env.CR_PAT }} | docker login ghcr.io -u ${{ env.DOCKER_GITHUB_USERNAME }} --password-stdin

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -7,10 +7,6 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-env:
-  CR_PAT: ${{ secrets.CR_PAT }}
-  DOCKER_GITHUB_USERNAME: ${{ secrets.DOCKER_GITHUB_USERNAME }}
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -23,7 +19,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Log in to GitHub Container Registry
-        run: echo ${{ env.CR_PAT }} | docker login ghcr.io -u ${{ env.DOCKER_GITHUB_USERNAME }} --password-stdin
+        run: echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GITHUB_USERNAME }}" --password-stdin
 
       - name: Build and Push Docker Images
         working-directory: ./server_go/deploy

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -1,0 +1,31 @@
+name: Docker Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  CR_PAT: ${{ secrets.CR_PAT }}
+  DOCKER_GITHUB_USERNAME: ${{ secrets.DOCKER_GITHUB_USERNAME }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Out Repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to GitHub Container Registry
+        run: echo ${{ env.CR_PAT }} | docker login ghcr.io -u ${{ env.DOCKER_GITHUB_USERNAME }} --password-stdin
+
+      - name: Build and Push Docker Images
+        working-directory: ./server_go/deploy
+        run: |
+          docker buildx bake -f docker-compose.server.yml --push

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -7,6 +7,11 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+env:
+  CR_PAT: ${{ secrets.CR_PAT }}
+  DOCKER_GITHUB_USERNAME: ${{ secrets.DOCKER_GITHUB_USERNAME }}
+
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,7 +24,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GITHUB_USERNAME }}" --password-stdin
+        run: echo ${{ env.CR_PAT }} | docker login ghcr.io -u ${{ env.DOCKER_GITHUB_USERNAME }} --password-stdin
 
       - name: Build and Push Docker Images
         working-directory: ./server_go/deploy


### PR DESCRIPTION
## Description
delivery.yml som tjekker koden ud fra repoet, sætter docker buildx op på GitHub runneren, logger ind på ghcr og kører docker buildx bake -f docker-compose.server.yml --push, så docker image bygges og pushes til ghcr.

### Changes Made
Tilføjet delivery.yml


### Why Was It Necessary


## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CI workflow to build and publish Docker images on pushes to main, pull requests targeting main, and on-demand; builds run on Ubuntu runners, use Docker Buildx, and push images to the container registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->