### PR TITLE
Added deploy and pipeline workflow for CD to production

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,25 @@
+name: Deploy
+
+on:
+  workflow_call:
+
+jobs:
+  deploy:
+    name: Deploy to production
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+            docker pull ghcr.io/devops-team36/whoknows:latest
+
+            cd /opt/whoknows
+
+            docker compose down
+            docker compose up -d

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -1,0 +1,16 @@
+name: Pipeline
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deliver:
+    uses: ./.github/workflows/delivery.yaml
+    secrets: inherit
+
+  deploy:
+    needs: deliver
+    uses: ./.github/workflows/deploy.yaml
+    secrets: inherit


### PR DESCRIPTION
## Description

### Changes Made
- Added deploy.yaml — reusable workflow that SSHs into the production server, logs into GHCR, pulls the latest image,
  and restarts the app via docker compose.
- Added pipeline.yaml — orchestrator workflow triggered on push to main and manual dispatch. Runs delivery first, then
   deploy.
- Added workflow_call trigger to delivery.yml so it can be called as a reusable workflow from the pipeline.


### Why Was It Necessary
We needed an automated CD pipeline so that merges to main automatically build, deliver, and deploy to production
without manual SSH/docker steps.




## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated production deployment workflow to support on-demand deployments invoked by other pipelines.
  * Implemented a CI/CD pipeline that triggers on main branch changes and manual dispatch, sequencing a delivery step followed by deployment and reusing shared pipeline components with inherited secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->