### PR TITLE
Added Air hot reload for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ cython_debug/
 # Database files
 *.db
 whoknows.db
+
+# Air hot reload
+server_go/tmp/

--- a/server_go/.air.toml
+++ b/server_go/.air.toml
@@ -1,0 +1,12 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  cmd = "go build -o ./tmp/whoknows-server.exe ./cmd/server"
+  bin = "./tmp/whoknows-server.exe"
+  include_ext = ["go", "html", "css", "js", "sql"]
+  exclude_dir = ["tmp", "docs", "deploy"]
+  delay = 1000
+
+[misc]
+  clean_on_exit = true

--- a/server_go/Makefile
+++ b/server_go/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run build test lint lint-fix swagger swagger-check clean docker-build docker-up docker-down deploy help
+.PHONY: run dev build test lint lint-fix swagger swagger-check clean docker-build docker-up docker-down deploy help
 
 BINARY    := whoknows-server
 MAIN      := ./cmd/server
@@ -12,6 +12,9 @@ help: ## Show this help
 
 run: ## Run the server locally
 	go run $(MAIN)
+
+dev: ## Run with hot reload (requires: go install github.com/air-verse/air@latest)
+	air
 
 build: ## Build the binary
 	go build -o $(BINARY) $(MAIN)


### PR DESCRIPTION
## Description

### Changes Made
- Added .air.toml config in server_go/ for Air hot reload, watching Go, HTML, CSS, JS, and SQL files
- Added make dev target in the Makefile to run Air
- Added server_go/tmp/ to .gitignore for Air's build artifacts


### Why Was It Necessary
Manual restart after every code change slows down development. Air automatically rebuilds and restarts the server on
file changes, making local development faster.




## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured hot-reload development environment for accelerated local development iteration and faster feedback cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->