### PR TITLE
Feat/weather

### DIFF
--- a/server_go/cmd/server/main.go
+++ b/server_go/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"whoknows_variations/server_go/internal/db"
 	"whoknows_variations/server_go/internal/httpapi"
 	"whoknows_variations/server_go/internal/queue"
+	"whoknows_variations/server_go/internal/weather"
 )
 
 // @title WhoKnows API
@@ -67,11 +68,12 @@ func main() {
 	}
 
 	s := &httpapi.Server{
-		DB:         pool,
-		Sessions:   store,
-		Queue:      queueClient,
-		ScraperKey: scraperKey,
-		ScrapeKey:  scrapeKey,
+		DB:             pool,
+		Sessions:       store,
+		Queue:          queueClient,
+		ScraperKey:     scraperKey,
+		ScrapeKey:      scrapeKey,
+		WeatherService: weather.NewService(),
 	}
 	router := httpapi.NewRouter(s)
 

--- a/server_go/docs/docs.go
+++ b/server_go/docs/docs.go
@@ -199,6 +199,34 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/weather": {
+            "get": {
+                "description": "Returns the current weather forecast.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "weather"
+                ],
+                "summary": "Weather",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "City name",
+                        "name": "city",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httpapi.StandardResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/login": {
             "get": {
                 "description": "Serves the login page as HTML.",
@@ -229,6 +257,34 @@ const docTemplate = `{
                     "pages"
                 ],
                 "summary": "Serve Register Page",
+                "responses": {
+                    "200": {
+                        "description": "HTML page",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/weather": {
+            "get": {
+                "description": "Serves the weather forecast page as HTML.",
+                "produces": [
+                    "text/html"
+                ],
+                "tags": [
+                    "pages"
+                ],
+                "summary": "Serve Weather Page",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "City name",
+                        "name": "city",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "HTML page",
@@ -283,6 +339,15 @@ const docTemplate = `{
                         "type": "object",
                         "additionalProperties": {}
                     }
+                }
+            }
+        },
+        "httpapi.StandardResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "additionalProperties": true
                 }
             }
         },

--- a/server_go/docs/swagger.json
+++ b/server_go/docs/swagger.json
@@ -193,6 +193,34 @@
                 }
             }
         },
+        "/api/weather": {
+            "get": {
+                "description": "Returns the current weather forecast.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "weather"
+                ],
+                "summary": "Weather",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "City name",
+                        "name": "city",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httpapi.StandardResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/login": {
             "get": {
                 "description": "Serves the login page as HTML.",
@@ -223,6 +251,34 @@
                     "pages"
                 ],
                 "summary": "Serve Register Page",
+                "responses": {
+                    "200": {
+                        "description": "HTML page",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/weather": {
+            "get": {
+                "description": "Serves the weather forecast page as HTML.",
+                "produces": [
+                    "text/html"
+                ],
+                "tags": [
+                    "pages"
+                ],
+                "summary": "Serve Weather Page",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "City name",
+                        "name": "city",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "HTML page",
@@ -277,6 +333,15 @@
                         "type": "object",
                         "additionalProperties": {}
                     }
+                }
+            }
+        },
+        "httpapi.StandardResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "additionalProperties": true
                 }
             }
         },

--- a/server_go/docs/swagger.yaml
+++ b/server_go/docs/swagger.yaml
@@ -29,6 +29,12 @@ definitions:
           type: object
         type: array
     type: object
+  httpapi.StandardResponse:
+    properties:
+      data:
+        additionalProperties: true
+        type: object
+    type: object
   httpapi.ValidationError:
     properties:
       loc:
@@ -170,6 +176,24 @@ paths:
       summary: Search
       tags:
       - search
+  /api/weather:
+    get:
+      description: Returns the current weather forecast.
+      parameters:
+      - description: City name
+        in: query
+        name: city
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httpapi.StandardResponse'
+      summary: Weather
+      tags:
+      - weather
   /login:
     get:
       description: Serves the login page as HTML.
@@ -194,6 +218,24 @@ paths:
           schema:
             type: string
       summary: Serve Register Page
+      tags:
+      - pages
+  /weather:
+    get:
+      description: Serves the weather forecast page as HTML.
+      parameters:
+      - description: City name
+        in: query
+        name: city
+        type: string
+      produces:
+      - text/html
+      responses:
+        "200":
+          description: HTML page
+          schema:
+            type: string
+      summary: Serve Weather Page
       tags:
       - pages
 swagger: "2.0"

--- a/server_go/internal/httpapi/handlers.go
+++ b/server_go/internal/httpapi/handlers.go
@@ -33,6 +33,10 @@ type SearchResponse struct {
 	Data []map[string]any `json:"data"`
 }
 
+type StandardResponse struct {
+	Data map[string]any `json:"data"`
+}
+
 type RequestValidationError struct {
 	StatusCode int     `json:"statusCode"`
 	Message    *string `json:"message"`
@@ -60,6 +64,7 @@ type ViewData struct {
 	Error   string
 	Results []map[string]any
 	Query   string
+	Weather map[string]any
 }
 
 // UserFromSession is chi middleware that loads the logged-in user (if any)
@@ -300,6 +305,24 @@ func (s *Server) ServeAboutPage(w http.ResponseWriter, r *http.Request) {
 	renderTemplate(w, "about.html", ViewData{User: currentUser(r), Flashes: s.getFlashes(w, r)})
 }
 
+// ServeWeatherPage godoc
+// @Summary Serve Weather Page
+// @Description Serves the weather forecast page as HTML.
+// @Tags pages
+// @Produce html
+// @Param city query string false "City name"
+// @Success 200 {string} string "HTML page"
+// @Router /weather [get]
+func (s *Server) ServeWeatherPage(w http.ResponseWriter, r *http.Request) {
+	city := strings.TrimSpace(r.URL.Query().Get("city"))
+	renderTemplate(w, "weather.html", ViewData{
+		User:    currentUser(r),
+		Flashes: s.getFlashes(w, r),
+		Query:   city,
+		Weather: s.weatherForecast(r, city),
+	})
+}
+
 // ServeRegisterPage godoc
 // @Summary Serve Register Page
 // @Description Serves the registration page as HTML.
@@ -361,11 +384,6 @@ func (s *Server) Search(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, SearchResponse{Data: []map[string]any{}})
 		return
 	}
-	metrics.ObserveSearch(time.Since(started), len(results))
-	if err := searchlog.LogSearch(q, lang, len(results)); err != nil {
-		log.Printf("search log write failed: %v", err)
-	}
-
 	metrics.ObserveSearch(time.Since(started), len(results))
 	if err := searchlog.LogSearch(q, lang, len(results)); err != nil {
 		log.Printf("search log write failed: %v", err)
@@ -482,6 +500,70 @@ func (s *Server) AddPage(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("indexed page: %s", page.Title)
 	writeJSON(w, http.StatusCreated, map[string]string{"message": "page indexed"})
+}
+
+// Weather godoc
+// @Summary Weather
+// @Description Returns the current weather forecast.
+// @Tags weather
+// @Produce json
+// @Param city query string false "City name"
+// @Success 200 {object} StandardResponse
+// @Router /api/weather [get]
+func (s *Server) Weather(w http.ResponseWriter, r *http.Request) {
+	city := strings.TrimSpace(r.URL.Query().Get("city"))
+	writeJSON(w, http.StatusOK, StandardResponse{Data: s.weatherForecast(r, city)})
+}
+
+func (s *Server) weatherForecast(r *http.Request, city string) map[string]any {
+	if s.WeatherService == nil {
+		return fallbackWeatherForecast(city)
+	}
+
+	forecast, err := s.WeatherService.Forecast(r.Context(), city)
+	if err != nil {
+		log.Printf("weather forecast failed: %v", err)
+		return fallbackWeatherForecast(city)
+	}
+	return forecast
+}
+
+func fallbackWeatherForecast(city string) map[string]any {
+	location := city
+	if location == "" {
+		location = "Copenhagen"
+	}
+	return map[string]any{
+		"location":        location,
+		"summary":         "Forecast temporarily unavailable.",
+		"icon":            "partly_cloudy_day",
+		"source":          "placeholder",
+		"temperature":     12,
+		"temperatureUnit": "celsius",
+		"forecast": []map[string]any{
+			{
+				"day":         "Today",
+				"condition":   "Cloudy",
+				"icon":        "cloud",
+				"temperature": 12,
+				"unit":        "celsius",
+			},
+			{
+				"day":         "Tomorrow",
+				"condition":   "Light rain",
+				"icon":        "rainy_light",
+				"temperature": 10,
+				"unit":        "celsius",
+			},
+			{
+				"day":         "Day 3",
+				"condition":   "Partly sunny",
+				"icon":        "partly_cloudy_day",
+				"temperature": 13,
+				"unit":        "celsius",
+			},
+		},
+	}
 }
 
 // Register godoc

--- a/server_go/internal/httpapi/openapi_contract_test.go
+++ b/server_go/internal/httpapi/openapi_contract_test.go
@@ -89,3 +89,24 @@ func TestAPIRegisterMissingEmailReturns422HTTPValidationError(t *testing.T) {
 		t.Fatal("expected at least one validation error detail")
 	}
 }
+
+func TestAPIWeatherReturnsStandardResponse(t *testing.T) {
+	s := testServer()
+	r := NewRouter(s)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/weather", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var body StandardResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("expected valid JSON response, got error: %v", err)
+	}
+	if body.Data == nil {
+		t.Fatal("expected data object in weather response")
+	}
+}

--- a/server_go/internal/httpapi/router.go
+++ b/server_go/internal/httpapi/router.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -18,11 +19,16 @@ import (
 const SessionName = "session"
 
 type Server struct {
-	DB         *pgxpool.Pool
-	Sessions   *sessions.CookieStore
-	Queue      *queue.Client
-	ScraperKey string // POST /api/pages — used by Azure Function scraper
-	ScrapeKey  string // POST /api/scrape — used by admins to trigger jobs
+	DB             *pgxpool.Pool
+	Sessions       *sessions.CookieStore
+	Queue          *queue.Client
+	ScraperKey     string // POST /api/pages — used by Azure Function scraper
+	ScrapeKey      string // POST /api/scrape — used by admins to trigger jobs
+	WeatherService WeatherProvider
+}
+
+type WeatherProvider interface {
+	Forecast(ctx context.Context, city string) (map[string]any, error)
 }
 
 func NewRouter(s *Server) http.Handler {
@@ -37,11 +43,13 @@ func NewRouter(s *Server) http.Handler {
 	// HTML routes
 	r.Get("/", s.ServeRootPage)
 	r.Get("/about", s.ServeAboutPage)
+	r.Get("/weather", s.ServeWeatherPage)
 	r.Get("/register", s.ServeRegisterPage)
 	r.Get("/login", s.ServeLoginPage)
 
 	// API routes
 	r.Get("/api/search", s.Search)
+	r.Get("/api/weather", s.Weather)
 	r.Post("/api/register", s.Register)
 	r.Post("/api/login", s.Login)
 	r.Get("/api/logout", s.Logout)

--- a/server_go/internal/httpapi/spec_match_test.go
+++ b/server_go/internal/httpapi/spec_match_test.go
@@ -12,10 +12,7 @@ import (
 )
 
 // Paths to skip when comparing (not implemented in our app).
-var skipPaths = map[string]bool{
-	"/weather":     true,
-	"/api/weather": true,
-}
+var skipPaths = map[string]bool{}
 
 func projectRoot() string {
 	_, file, _, _ := runtime.Caller(0)

--- a/server_go/internal/weather/service.go
+++ b/server_go/internal/weather/service.go
@@ -1,0 +1,345 @@
+package weather
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultLocation = "Copenhagen"
+)
+
+type Service struct {
+	client           *http.Client
+	forecastEndpoint string
+	geocodeEndpoint  string
+	ttl              time.Duration
+
+	mu        sync.RWMutex
+	refreshMu sync.Mutex
+	cached    map[string]cachedForecast
+}
+
+type cachedForecast struct {
+	data      map[string]any
+	expiresAt time.Time
+}
+
+type geocodingResponse struct {
+	Results []location `json:"results"`
+}
+
+type location struct {
+	Name      string  `json:"name"`
+	Country   string  `json:"country"`
+	Admin1    string  `json:"admin1"`
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+	Timezone  string  `json:"timezone"`
+}
+
+type openMeteoResponse struct {
+	Current struct {
+		Temperature float64 `json:"temperature_2m"`
+		WeatherCode int     `json:"weather_code"`
+	} `json:"current"`
+	Daily struct {
+		Time           []string  `json:"time"`
+		WeatherCode    []int     `json:"weather_code"`
+		TemperatureMax []float64 `json:"temperature_2m_max"`
+		TemperatureMin []float64 `json:"temperature_2m_min"`
+	} `json:"daily"`
+}
+
+func NewService() *Service {
+	return &Service{
+		client: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+		forecastEndpoint: "https://api.open-meteo.com/v1/forecast",
+		geocodeEndpoint:  "https://geocoding-api.open-meteo.com/v1/search",
+		ttl:              15 * time.Minute,
+		cached:           map[string]cachedForecast{},
+	}
+}
+
+func (s *Service) Forecast(ctx context.Context, city string) (map[string]any, error) {
+	city = normalizeCity(city)
+	now := time.Now()
+	if data, ok := s.fresh(city, now); ok {
+		return data, nil
+	}
+
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+
+	now = time.Now()
+	if data, ok := s.fresh(city, now); ok {
+		return data, nil
+	}
+
+	data, err := s.fetch(ctx, city)
+	if err != nil {
+		if stale, ok := s.stale(city); ok {
+			stale["stale"] = true
+			return stale, nil
+		}
+		return nil, err
+	}
+
+	s.mu.Lock()
+	s.cached[cacheKey(city)] = cachedForecast{
+		data:      data,
+		expiresAt: now.Add(s.ttl),
+	}
+	s.mu.Unlock()
+
+	return data, nil
+}
+
+func (s *Service) fresh(city string, now time.Time) (map[string]any, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	cached := s.cached[cacheKey(city)]
+	if cached.data == nil || now.After(cached.expiresAt) {
+		return nil, false
+	}
+	return cloneMap(cached.data), true
+}
+
+func (s *Service) stale(city string) (map[string]any, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	cached := s.cached[cacheKey(city)]
+	if cached.data == nil {
+		return nil, false
+	}
+	return cloneMap(cached.data), true
+}
+
+func (s *Service) fetch(ctx context.Context, city string) (map[string]any, error) {
+	location, err := s.geocode(ctx, city)
+	if err != nil {
+		return nil, err
+	}
+
+	reqURL, err := url.Parse(s.forecastEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	q := reqURL.Query()
+	q.Set("latitude", fmt.Sprintf("%f", location.Latitude))
+	q.Set("longitude", fmt.Sprintf("%f", location.Longitude))
+	q.Set("current", "temperature_2m,weather_code")
+	q.Set("daily", "weather_code,temperature_2m_max,temperature_2m_min")
+	q.Set("timezone", location.Timezone)
+	q.Set("forecast_days", "3")
+	reqURL.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("open-meteo returned status %d", resp.StatusCode)
+	}
+
+	var payload openMeteoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+
+	return normalize(payload, location, s.ttl), nil
+}
+
+func (s *Service) geocode(ctx context.Context, city string) (location, error) {
+	reqURL, err := url.Parse(s.geocodeEndpoint)
+	if err != nil {
+		return location{}, err
+	}
+
+	q := reqURL.Query()
+	q.Set("name", city)
+	q.Set("count", "1")
+	q.Set("language", "en")
+	q.Set("format", "json")
+	reqURL.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
+	if err != nil {
+		return location{}, err
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return location{}, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return location{}, fmt.Errorf("open-meteo geocoding returned status %d", resp.StatusCode)
+	}
+
+	var payload geocodingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return location{}, err
+	}
+	if len(payload.Results) == 0 {
+		return location{}, fmt.Errorf("city %q not found", city)
+	}
+	if payload.Results[0].Timezone == "" {
+		payload.Results[0].Timezone = "auto"
+	}
+	return payload.Results[0], nil
+}
+
+func normalize(payload openMeteoResponse, loc location, ttl time.Duration) map[string]any {
+	forecast := make([]map[string]any, 0, len(payload.Daily.Time))
+	for i, date := range payload.Daily.Time {
+		if i >= len(payload.Daily.WeatherCode) || i >= len(payload.Daily.TemperatureMax) || i >= len(payload.Daily.TemperatureMin) {
+			break
+		}
+
+		var day string
+		switch i {
+		case 0:
+			day = "Today"
+		case 1:
+			day = "Tomorrow"
+		default:
+			day = "Day " + fmt.Sprint(i+1)
+		}
+
+		forecast = append(forecast, map[string]any{
+			"date":        date,
+			"day":         day,
+			"condition":   weatherDescription(payload.Daily.WeatherCode[i]),
+			"icon":        weatherIcon(payload.Daily.WeatherCode[i]),
+			"temperature": int(math.Round(payload.Daily.TemperatureMax[i])),
+			"min":         int(math.Round(payload.Daily.TemperatureMin[i])),
+			"max":         int(math.Round(payload.Daily.TemperatureMax[i])),
+			"unit":        "celsius",
+		})
+	}
+
+	currentTemp := int(math.Round(payload.Current.Temperature))
+	if currentTemp == 0 && len(forecast) > 0 {
+		currentTemp, _ = forecast[0]["temperature"].(int)
+	}
+
+	return map[string]any{
+		"location":            displayName(loc),
+		"summary":             weatherDescription(payload.Current.WeatherCode),
+		"icon":                weatherIcon(payload.Current.WeatherCode),
+		"source":              "open-meteo",
+		"temperature":         currentTemp,
+		"temperatureUnit":     "celsius",
+		"forecast":            forecast,
+		"cachedSeconds":       int(ttl.Seconds()),
+		"latitude":            loc.Latitude,
+		"longitude":           loc.Longitude,
+		"providerAttribution": "Weather data by Open-Meteo.com",
+	}
+}
+
+func normalizeCity(city string) string {
+	city = strings.TrimSpace(city)
+	if city == "" {
+		return defaultLocation
+	}
+	return city
+}
+
+func cacheKey(city string) string {
+	return strings.ToLower(normalizeCity(city))
+}
+
+func displayName(loc location) string {
+	parts := []string{loc.Name}
+	if loc.Admin1 != "" && loc.Admin1 != loc.Name {
+		parts = append(parts, loc.Admin1)
+	}
+	if loc.Country != "" {
+		parts = append(parts, loc.Country)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func weatherDescription(code int) string {
+	switch code {
+	case 0:
+		return "Clear sky"
+	case 1, 2:
+		return "Partly cloudy"
+	case 3:
+		return "Overcast"
+	case 45, 48:
+		return "Fog"
+	case 51, 53, 55, 56, 57:
+		return "Drizzle"
+	case 61, 63, 65, 66, 67:
+		return "Rain"
+	case 71, 73, 75, 77:
+		return "Snow"
+	case 80, 81, 82:
+		return "Rain showers"
+	case 85, 86:
+		return "Snow showers"
+	case 95, 96, 99:
+		return "Thunderstorm"
+	default:
+		return "Forecast available"
+	}
+}
+
+func weatherIcon(code int) string {
+	switch code {
+	case 0:
+		return "clear_day"
+	case 1, 2:
+		return "partly_cloudy_day"
+	case 3:
+		return "cloud"
+	case 45, 48:
+		return "foggy"
+	case 51, 53, 55, 56, 57:
+		return "rainy_light"
+	case 61, 63, 65, 66, 67, 80, 81, 82:
+		return "rainy"
+	case 71, 73, 75, 77, 85, 86:
+		return "weather_snowy"
+	case 95, 96, 99:
+		return "thunderstorm"
+	default:
+		return "partly_cloudy_day"
+	}
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/server_go/internal/weather/service_test.go
+++ b/server_go/internal/weather/service_test.go
@@ -1,0 +1,166 @@
+package weather
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestForecastCachesProviderResponse(t *testing.T) {
+	calls := 0
+	service := NewService()
+	service.geocodeEndpoint = "https://open-meteo.test/v1/search"
+	service.forecastEndpoint = "https://open-meteo.test/v1/forecast"
+	service.ttl = time.Hour
+	service.client = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		if r.URL.Path == "/v1/search" {
+			return jsonResponse(http.StatusOK, `{
+				"results": [{
+					"name": "Aarhus",
+					"admin1": "Central Jutland",
+					"country": "Denmark",
+					"latitude": 56.1567,
+					"longitude": 10.2108,
+					"timezone": "Europe/Copenhagen"
+				}]
+			}`), nil
+		}
+		return jsonResponse(http.StatusOK, `{
+			"current": {"temperature_2m": 8.4, "weather_code": 3},
+			"daily": {
+				"time": ["2026-05-18", "2026-05-19", "2026-05-20"],
+				"weather_code": [3, 61, 1],
+				"temperature_2m_max": [9.2, 11.1, 13.4],
+				"temperature_2m_min": [4.1, 6.2, 7.0]
+			}
+		}`), nil
+	})}
+
+	first, err := service.Forecast(context.Background(), "Aarhus")
+	if err != nil {
+		t.Fatalf("first forecast failed: %v", err)
+	}
+	second, err := service.Forecast(context.Background(), "Aarhus")
+	if err != nil {
+		t.Fatalf("second forecast failed: %v", err)
+	}
+
+	if calls != 2 {
+		t.Fatalf("expected one geocoding call and one forecast call, got %d", calls)
+	}
+	if first["source"] != "open-meteo" || second["source"] != "open-meteo" {
+		t.Fatalf("expected Open-Meteo source, got first=%v second=%v", first["source"], second["source"])
+	}
+	if first["location"] != "Aarhus, Central Jutland, Denmark" {
+		t.Fatalf("expected resolved city name, got %v", first["location"])
+	}
+}
+
+func TestForecastReturnsStaleCacheOnProviderFailure(t *testing.T) {
+	calls := 0
+	service := NewService()
+	service.geocodeEndpoint = "https://open-meteo.test/v1/search"
+	service.forecastEndpoint = "https://open-meteo.test/v1/forecast"
+	service.ttl = -time.Second
+	service.client = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		if r.URL.Path == "/v1/search" {
+			return jsonResponse(http.StatusOK, `{
+				"results": [{
+					"name": "Copenhagen",
+					"country": "Denmark",
+					"latitude": 55.6761,
+					"longitude": 12.5683,
+					"timezone": "Europe/Copenhagen"
+				}]
+			}`), nil
+		}
+		if calls == 2 {
+			return jsonResponse(http.StatusOK, `{
+				"current": {"temperature_2m": 5, "weather_code": 0},
+				"daily": {
+					"time": ["2026-05-18"],
+					"weather_code": [0],
+					"temperature_2m_max": [6],
+					"temperature_2m_min": [2]
+				}
+			}`), nil
+		}
+		return jsonResponse(http.StatusBadGateway, `provider down`), nil
+	})}
+
+	if _, err := service.Forecast(context.Background(), "Copenhagen"); err != nil {
+		t.Fatalf("initial forecast failed: %v", err)
+	}
+	stale, err := service.Forecast(context.Background(), "Copenhagen")
+	if err != nil {
+		t.Fatalf("expected stale forecast, got error: %v", err)
+	}
+	if stale["stale"] != true {
+		t.Fatalf("expected stale marker, got %v", stale["stale"])
+	}
+}
+
+func TestForecastCachesPerCity(t *testing.T) {
+	forecastCalls := 0
+	service := NewService()
+	service.geocodeEndpoint = "https://open-meteo.test/v1/search"
+	service.forecastEndpoint = "https://open-meteo.test/v1/forecast"
+	service.ttl = time.Hour
+	service.client = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path == "/v1/search" {
+			city := r.URL.Query().Get("name")
+			return jsonResponse(http.StatusOK, `{
+				"results": [{
+					"name": "`+city+`",
+					"country": "Denmark",
+					"latitude": 55,
+					"longitude": 12,
+					"timezone": "Europe/Copenhagen"
+				}]
+			}`), nil
+		}
+		forecastCalls++
+		return jsonResponse(http.StatusOK, `{
+			"current": {"temperature_2m": 7, "weather_code": 1},
+			"daily": {
+				"time": ["2026-05-18"],
+				"weather_code": [1],
+				"temperature_2m_max": [8],
+				"temperature_2m_min": [3]
+			}
+		}`), nil
+	})}
+
+	if _, err := service.Forecast(context.Background(), "Odense"); err != nil {
+		t.Fatalf("odense forecast failed: %v", err)
+	}
+	if _, err := service.Forecast(context.Background(), "Odense"); err != nil {
+		t.Fatalf("cached odense forecast failed: %v", err)
+	}
+	if _, err := service.Forecast(context.Background(), "Aalborg"); err != nil {
+		t.Fatalf("aalborg forecast failed: %v", err)
+	}
+
+	if forecastCalls != 2 {
+		t.Fatalf("expected one forecast call per city, got %d", forecastCalls)
+	}
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+}

--- a/server_go/openapi/openapi.json
+++ b/server_go/openapi/openapi.json
@@ -27,6 +27,18 @@
             "get": {
                 "summary": "Serve Weather Page",
                 "operationId": "serve_weather_page_weather_get",
+                "parameters": [
+                    {
+                        "name": "city",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "title": "City"
+                        },
+                        "description": "City name"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Successful Response",
@@ -138,6 +150,18 @@
             "get": {
                 "summary": "Weather",
                 "operationId": "weather_api_weather_get",
+                "parameters": [
+                    {
+                        "name": "city",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "title": "City"
+                        },
+                        "description": "City name"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Successful Response",

--- a/server_go/static/style.css
+++ b/server_go/static/style.css
@@ -828,3 +828,240 @@ img {
   filter: grayscale(1);
   opacity: 0.9;
 }
+
+
+/* ============================================================
+   WEATHER PAGE
+   ============================================================ */
+
+.weather-page {
+  min-height: 100vh;
+  padding: 8rem 1.5rem 5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.weather-panel {
+  width: 100%;
+  max-width: 42rem;
+  background: var(--surface-container-lowest);
+  border-radius: 0.5rem;
+  box-shadow: var(--shadow-ghost);
+  padding: 2.5rem;
+}
+
+.weather-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--surface-variant);
+}
+
+.weather-eyebrow {
+  font-size: 0.625rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--primary);
+  margin-bottom: 0.75rem;
+}
+
+.weather-title {
+  font-family: var(--font-headline);
+  font-weight: 800;
+  font-size: 2.25rem;
+  line-height: 1.1;
+  color: var(--on-surface);
+  margin-bottom: 0.75rem;
+}
+
+.weather-summary {
+  max-width: 30rem;
+  font-size: 0.9375rem;
+  color: var(--on-surface-variant);
+}
+
+.weather-location {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex-shrink: 0;
+  padding: 0.5rem 0.75rem;
+  background: var(--surface-container-low);
+  border-radius: 0.5rem;
+  color: var(--on-surface-variant);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.weather-location .material-symbols-outlined {
+  font-size: 1rem;
+  color: var(--primary);
+}
+
+.weather-search {
+  padding: 1.5rem 0 0;
+}
+
+.weather-search-label {
+  display: block;
+  font-size: 0.625rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--on-surface-variant);
+  margin-bottom: 0.5rem;
+}
+
+.weather-search-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  padding: 0.5rem 0.5rem 0.5rem 1rem;
+  background: var(--surface-container-low);
+  border-radius: 9999px;
+}
+
+.weather-search-bar .material-symbols-outlined {
+  color: var(--on-surface-variant);
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+.weather-search-bar input {
+  min-width: 0;
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-family: var(--font-body);
+  font-size: 1rem;
+  color: var(--on-surface);
+  outline: none;
+}
+
+.weather-search-bar input::placeholder {
+  color: var(--outline);
+}
+
+.weather-current {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 2rem 0;
+}
+
+.weather-current > .material-symbols-outlined {
+  width: 4rem;
+  height: 4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--primary-container);
+  color: var(--on-primary-container);
+  border-radius: 0.5rem;
+  font-size: 2rem;
+}
+
+.weather-current-label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--on-surface-variant);
+  margin-bottom: 0.25rem;
+}
+
+.weather-current strong {
+  display: block;
+  font-family: var(--font-headline);
+  font-size: 3rem;
+  line-height: 1;
+  color: var(--on-surface);
+}
+
+.weather-forecast {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.weather-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  background: var(--surface-container-low);
+  border-radius: 0.5rem;
+}
+
+.weather-row-main {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  min-width: 0;
+}
+
+.weather-row-main .material-symbols-outlined {
+  color: var(--primary);
+  font-size: 1.5rem;
+  flex-shrink: 0;
+}
+
+.weather-row h2 {
+  font-family: var(--font-headline);
+  font-size: 1rem;
+  line-height: 1.2;
+  color: var(--on-surface);
+}
+
+.weather-row p {
+  font-size: 0.8125rem;
+  color: var(--on-surface-variant);
+}
+
+.weather-row strong {
+  font-family: var(--font-headline);
+  font-size: 1.25rem;
+  color: var(--primary);
+  flex-shrink: 0;
+}
+
+@media (max-width: 640px) {
+  .weather-page {
+    align-items: flex-start;
+    padding-top: 7rem;
+  }
+
+  .weather-panel {
+    padding: 1.5rem;
+  }
+
+  .weather-header {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .weather-title {
+    font-size: 1.875rem;
+  }
+
+  .weather-search-bar {
+    border-radius: 0.5rem;
+    align-items: stretch;
+    flex-wrap: wrap;
+  }
+
+  .weather-search-bar input {
+    flex-basis: calc(100% - 2.5rem);
+  }
+
+  .weather-search-bar .btn-search {
+    width: 100%;
+  }
+}

--- a/server_go/templates/layout.html
+++ b/server_go/templates/layout.html
@@ -24,6 +24,7 @@
       <div style="display:flex;align-items:center;gap:2rem;">
         <a class="nav-logo" href="/">WhoKnows</a>
         <a class="nav-link" href="/about">About</a>
+        <a class="nav-link" href="/weather">Weather</a>
       </div>
       <div class="nav-links">
         {{ if .User }}
@@ -52,6 +53,7 @@
   <footer class="site-footer">
     <div class="footer-links">
       <a class="footer-link" href="/about">About</a>
+      <a class="footer-link" href="/weather">Weather</a>
       <a class="footer-link" href="#">Privacy</a>
       <a class="footer-link" href="#">Terms</a>
     </div>

--- a/server_go/templates/weather.html
+++ b/server_go/templates/weather.html
@@ -1,0 +1,52 @@
+{{ define "body" }}
+<main class="weather-page">
+  <section class="weather-panel">
+    <div class="weather-header">
+      <div>
+        <h1 class="weather-title">Weather forecast</h1>
+        <p class="weather-summary">{{ index .Weather "summary" }}</p>
+      </div>
+      <div class="weather-location">
+        <span class="material-symbols-outlined">location_on</span>
+        <span>{{ index .Weather "location" }}</span>
+      </div>
+    </div>
+
+    <form class="weather-search" action="/weather" method="get">
+      <label class="weather-search-label" for="weather-city">City</label>
+      <div class="weather-search-bar">
+        <span class="material-symbols-outlined">search</span>
+        <input id="weather-city" name="city" type="text" placeholder="Search city..." value="{{ .Query }}">
+        <button class="btn-search" type="submit">Search</button>
+      </div>
+    </form>
+
+    <div class="weather-current">
+      <span class="material-symbols-outlined">{{ index .Weather "icon" }}</span>
+      <div>
+        <span class="weather-current-label">Current outlook</span>
+        <strong>{{ index .Weather "temperature" }}&deg;C</strong>
+      </div>
+    </div>
+
+    <section class="weather-forecast" aria-label="Weather forecast">
+      {{ range index .Weather "forecast" }}
+      <article class="weather-row">
+        <div class="weather-row-main">
+          <span class="material-symbols-outlined">{{ index . "icon" }}</span>
+          <div>
+            <h2>{{ index . "day" }}</h2>
+            <p>{{ index . "condition" }}</p>
+          </div>
+        </div>
+        <strong>{{ index . "temperature" }}&deg;C</strong>
+      </article>
+      {{ end }}
+    </section>
+  </section>
+</main>
+{{ end }}
+
+{{ define "weather.html" }}
+  {{ template "layout" . }}
+{{ end }}


### PR DESCRIPTION
Adds a weather page and API endpoint to the Go web app. Users can search for a city and view current weather plus a short forecast using Open-Meteo data.

### Changes Made
- Added /weather HTML route with a city search form.
- Added /api/weather JSON endpoint with optional city query parameter.
- Integrated Open-Meteo geocoding and forecast APIs.
- Added an in-memory per-city weather cache with a 15-minute TTL.
- Added stale-cache fallback if the provider is temporarily unavailable.
- Added weather condition mapping for labels and icons.
- Added weather page styling consistent with the existing site.
- Updated OpenAPI/Swagger docs for the new endpoints.
- Added tests for weather caching, stale fallback, per-city cache behavior, and API response shape.


### Why Was It Necessary
Consumers are now interested in weather forecasts, so the app needs a weather page that displays forecast data from a third-party service. 

The backend integration keeps provider logic server-side, avoids exposing provider details to the frontend, and allows caching to reduce repeated calls to the external service. The in-memory cache helps the app scale better by serving repeated city lookups locally for a fixed interval instead of calling Open-Meteo on every request.




## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change

