### PR TITLE
feat: run E2E tests against Docker image instead of bare binary

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,40 +14,12 @@ jobs:
   playwright:
     name: Playwright E2E
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:17-alpine
-        env:
-          POSTGRES_USER: test
-          POSTGRES_PASSWORD: test
-          POSTGRES_DB: whoknows_e2e
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
-    env:
-      DATABASE_URL: postgres://test:test@localhost:5432/whoknows_e2e?sslmode=disable
     steps:
       - uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2
 
-      - name: Set up Go
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
-        with:
-          go-version: '1.25.9'
-          cache-dependency-path: server_go/go.sum
-
-      - name: Build server
+      - name: Start services
         working-directory: server_go
-        run: go build -o whoknows ./cmd/server
-
-      - name: Start server
-        working-directory: server_go
-        run: |
-          ./whoknows &
-          sleep 2
+        run: docker compose -f docker-compose.e2e.yml up -d --build --wait
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
@@ -75,3 +47,8 @@ jobs:
           name: playwright-report
           path: server_go/e2e/playwright-report/
           retention-days: 30
+
+      - name: Tear down services
+        if: always()
+        working-directory: server_go
+        run: docker compose -f docker-compose.e2e.yml down -v

--- a/server_go/docker-compose.e2e.yml
+++ b/server_go/docker-compose.e2e.yml
@@ -1,0 +1,41 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: whoknows_e2e
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=128MB"
+      - "-c"
+      - "work_mem=4MB"
+      - "-c"
+      - "effective_cache_size=256MB"
+      - "-c"
+      - "max_connections=20"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U test -d whoknows_e2e"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  whoknows:
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+    environment:
+      DATABASE_URL: postgres://test:test@postgres:5432/whoknows_e2e?sslmode=disable
+      WHOKNOWS_PORT: "8080"
+      WHOKNOWS_ADDR: "0.0.0.0"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/"]
+      interval: 5s
+      timeout: 3s
+      retries: 10


### PR DESCRIPTION
# Why Was It Necessary

The previous E2E setup compiled a Go binary directly on the Ubuntu runner and ran it against a plain Postgres service container. This meant we weren't testing the actual artifact that gets deployed — the Docker image. Bugs introduced by the Dockerfile (missing COPY paths for templates/static/migrations, wrong base image, missing ca-certificates, CGO_ENABLED=0 issues) would pass CI but break in production.

Since our production stack runs the app inside a container with Docker networking (connecting to Postgres via hostname, not localhost) and tuned Postgres settings, the E2E environment should match that as closely as possible.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change
