### PR TITLE
feat: add terraform provisioning for DigitalOcean with Cloudflare DNS

### DIFF
--- a/server_go/Makefile
+++ b/server_go/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run dev build test lint lint-fix swagger swagger-check clean docker-build docker-up docker-down deploy help
+.PHONY: run dev build test lint lint-fix swagger swagger-check clean docker-build docker-up docker-down deploy spinup spinup-app spinup-monitoring help
 
 BINARY    := whoknows-server
 MAIN      := ./cmd/server
@@ -54,6 +54,15 @@ deploy: ## Deploy to production via Ansible
 
 deploy-check: ## Ansible dry-run (no changes)
 	ansible-playbook deploy/ansible/playbook.yml --check
+
+spinup: ## Spin up begge servere fra scratch (Terraform + DNS + Ansible)
+	bash deploy/spinup.sh all
+
+spinup-app: ## Spin up kun app-server (brug når kun huw.dk er nede)
+	bash deploy/spinup.sh app
+
+spinup-monitoring: ## Spin up kun monitoring-server (brug når monitor.huw.dk er nede)
+	bash deploy/spinup.sh monitoring
 
 # ── Maintenance ─────────────────────────────────────────────
 

--- a/server_go/deploy/spinup.sh
+++ b/server_go/deploy/spinup.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 MODE="${1:-all}"
 
 if [[ "$MODE" != "app" && "$MODE" != "monitoring" && "$MODE" != "all" ]]; then
-  echo "Brug: bash deploy/spinup.sh [app|monitoring|all]"
-  exit 1
+    echo "Brug: bash deploy/spinup.sh [app|monitoring|all]"
+    exit 1
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -19,36 +19,36 @@ echo "==> Initialiserer Terraform..."
 cd "$TERRAFORM_DIR"
 
 if [ ! -f terraform.tfvars ]; then
-  echo "FEJL: $TERRAFORM_DIR/terraform.tfvars mangler."
-  echo "Kopiér terraform.tfvars.example og udfyld værdierne."
-  exit 1
+    echo "FEJL: $TERRAFORM_DIR/terraform.tfvars mangler."
+    echo "Kopiér terraform.tfvars.example og udfyld værdierne."
+    exit 1
 fi
 
 terraform init -upgrade
 
 case "$MODE" in
-  app)
+app)
     terraform apply -auto-approve \
-      -target=digitalocean_droplet.whoknows \
-      -target=digitalocean_firewall.whoknows \
-      -target=cloudflare_record.whoknows_a
+        -target=digitalocean_droplet.whoknows \
+        -target=digitalocean_firewall.whoknows \
+        -target=cloudflare_record.whoknows_a
     APP_IP=$(terraform output -raw droplet_ip)
     echo "==> App-server IP: $APP_IP"
     sed -i.bak "/whoknows-vm/{n;s/ansible_host: .*/ansible_host: $APP_IP/}" "$INVENTORY"
     sed -i.bak "s/server_ip: .*/server_ip: \"$APP_IP\"/" "$INVENTORY"
     rm -f "$INVENTORY.bak"
     ;;
-  monitoring)
+monitoring)
     terraform apply -auto-approve \
-      -target=digitalocean_droplet.monitoring \
-      -target=digitalocean_firewall.monitoring \
-      -target=cloudflare_record.monitoring_a
+        -target=digitalocean_droplet.monitoring \
+        -target=digitalocean_firewall.monitoring \
+        -target=cloudflare_record.monitoring_a
     MONITORING_IP=$(terraform output -raw monitoring_ip)
     echo "==> Monitoring-server IP: $MONITORING_IP"
     sed -i.bak "/monitoring-vm/{n;s/ansible_host: .*/ansible_host: $MONITORING_IP/}" "$INVENTORY"
     rm -f "$INVENTORY.bak"
     ;;
-  all)
+all)
     terraform apply -auto-approve
     APP_IP=$(terraform output -raw droplet_ip)
     MONITORING_IP=$(terraform output -raw monitoring_ip)
@@ -70,17 +70,17 @@ echo "==> Kører Ansible playbook..."
 cd "$ANSIBLE_DIR/.."
 
 case "$MODE" in
-  app)
+app)
     ansible-playbook deploy/ansible/playbook.yml --limit production
     echo ""
     echo "==> Færdig! App:        https://huw.dk ($APP_IP)"
     ;;
-  monitoring)
+monitoring)
     ansible-playbook deploy/ansible/playbook.yml --limit monitoring
     echo ""
     echo "==> Færdig! Monitoring: https://monitor.huw.dk ($MONITORING_IP)"
     ;;
-  all)
+all)
     ansible-playbook deploy/ansible/playbook.yml
     echo ""
     echo "==> Færdig!"

--- a/server_go/deploy/spinup.sh
+++ b/server_go/deploy/spinup.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 MODE="${1:-all}"
 
 if [[ "$MODE" != "app" && "$MODE" != "monitoring" && "$MODE" != "all" ]]; then
-    echo "Brug: bash deploy/spinup.sh [app|monitoring|all]"
-    exit 1
+	echo "Brug: bash deploy/spinup.sh [app|monitoring|all]"
+	exit 1
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -19,46 +19,46 @@ echo "==> Initialiserer Terraform..."
 cd "$TERRAFORM_DIR"
 
 if [ ! -f terraform.tfvars ]; then
-    echo "FEJL: $TERRAFORM_DIR/terraform.tfvars mangler."
-    echo "Kopiér terraform.tfvars.example og udfyld værdierne."
-    exit 1
+	echo "FEJL: $TERRAFORM_DIR/terraform.tfvars mangler."
+	echo "Kopiér terraform.tfvars.example og udfyld værdierne."
+	exit 1
 fi
 
 terraform init -upgrade
 
 case "$MODE" in
 app)
-    terraform apply -auto-approve \
-        -target=digitalocean_droplet.whoknows \
-        -target=digitalocean_firewall.whoknows \
-        -target=cloudflare_record.whoknows_a
-    APP_IP=$(terraform output -raw droplet_ip)
-    echo "==> App-server IP: $APP_IP"
-    sed -i.bak "/whoknows-vm/{n;s/ansible_host: .*/ansible_host: $APP_IP/}" "$INVENTORY"
-    sed -i.bak "s/server_ip: .*/server_ip: \"$APP_IP\"/" "$INVENTORY"
-    rm -f "$INVENTORY.bak"
-    ;;
+	terraform apply -auto-approve \
+		-target=digitalocean_droplet.whoknows \
+		-target=digitalocean_firewall.whoknows \
+		-target=cloudflare_record.whoknows_a
+	APP_IP=$(terraform output -raw droplet_ip)
+	echo "==> App-server IP: $APP_IP"
+	sed -i.bak "/whoknows-vm/{n;s/ansible_host: .*/ansible_host: $APP_IP/}" "$INVENTORY"
+	sed -i.bak "s/server_ip: .*/server_ip: \"$APP_IP\"/" "$INVENTORY"
+	rm -f "$INVENTORY.bak"
+	;;
 monitoring)
-    terraform apply -auto-approve \
-        -target=digitalocean_droplet.monitoring \
-        -target=digitalocean_firewall.monitoring \
-        -target=cloudflare_record.monitoring_a
-    MONITORING_IP=$(terraform output -raw monitoring_ip)
-    echo "==> Monitoring-server IP: $MONITORING_IP"
-    sed -i.bak "/monitoring-vm/{n;s/ansible_host: .*/ansible_host: $MONITORING_IP/}" "$INVENTORY"
-    rm -f "$INVENTORY.bak"
-    ;;
+	terraform apply -auto-approve \
+		-target=digitalocean_droplet.monitoring \
+		-target=digitalocean_firewall.monitoring \
+		-target=cloudflare_record.monitoring_a
+	MONITORING_IP=$(terraform output -raw monitoring_ip)
+	echo "==> Monitoring-server IP: $MONITORING_IP"
+	sed -i.bak "/monitoring-vm/{n;s/ansible_host: .*/ansible_host: $MONITORING_IP/}" "$INVENTORY"
+	rm -f "$INVENTORY.bak"
+	;;
 all)
-    terraform apply -auto-approve
-    APP_IP=$(terraform output -raw droplet_ip)
-    MONITORING_IP=$(terraform output -raw monitoring_ip)
-    echo "==> App-server IP:        $APP_IP"
-    echo "==> Monitoring-server IP: $MONITORING_IP"
-    sed -i.bak "/whoknows-vm/{n;s/ansible_host: .*/ansible_host: $APP_IP/}" "$INVENTORY"
-    sed -i.bak "/monitoring-vm/{n;s/ansible_host: .*/ansible_host: $MONITORING_IP/}" "$INVENTORY"
-    sed -i.bak "s/server_ip: .*/server_ip: \"$APP_IP\"/" "$INVENTORY"
-    rm -f "$INVENTORY.bak"
-    ;;
+	terraform apply -auto-approve
+	APP_IP=$(terraform output -raw droplet_ip)
+	MONITORING_IP=$(terraform output -raw monitoring_ip)
+	echo "==> App-server IP:        $APP_IP"
+	echo "==> Monitoring-server IP: $MONITORING_IP"
+	sed -i.bak "/whoknows-vm/{n;s/ansible_host: .*/ansible_host: $APP_IP/}" "$INVENTORY"
+	sed -i.bak "/monitoring-vm/{n;s/ansible_host: .*/ansible_host: $MONITORING_IP/}" "$INVENTORY"
+	sed -i.bak "s/server_ip: .*/server_ip: \"$APP_IP\"/" "$INVENTORY"
+	rm -f "$INVENTORY.bak"
+	;;
 esac
 
 # --- Vent på at cloud-init er klar ---
@@ -71,22 +71,22 @@ cd "$ANSIBLE_DIR/.."
 
 case "$MODE" in
 app)
-    ansible-playbook deploy/ansible/playbook.yml --limit production
-    echo ""
-    echo "==> Færdig! App:        https://huw.dk ($APP_IP)"
-    ;;
+	ansible-playbook deploy/ansible/playbook.yml --limit production
+	echo ""
+	echo "==> Færdig! App:        https://huw.dk ($APP_IP)"
+	;;
 monitoring)
-    ansible-playbook deploy/ansible/playbook.yml --limit monitoring
-    echo ""
-    echo "==> Færdig! Monitoring: https://monitor.huw.dk ($MONITORING_IP)"
-    ;;
+	ansible-playbook deploy/ansible/playbook.yml --limit monitoring
+	echo ""
+	echo "==> Færdig! Monitoring: https://monitor.huw.dk ($MONITORING_IP)"
+	;;
 all)
-    ansible-playbook deploy/ansible/playbook.yml
-    echo ""
-    echo "==> Færdig!"
-    echo "    App:        https://huw.dk         ($APP_IP)"
-    echo "    Monitoring: https://monitor.huw.dk ($MONITORING_IP)"
-    ;;
+	ansible-playbook deploy/ansible/playbook.yml
+	echo ""
+	echo "==> Færdig!"
+	echo "    App:        https://huw.dk         ($APP_IP)"
+	echo "    Monitoring: https://monitor.huw.dk ($MONITORING_IP)"
+	;;
 esac
 
 echo "    DNS er automatisk opdateret af Terraform (Cloudflare)."

--- a/server_go/deploy/spinup.sh
+++ b/server_go/deploy/spinup.sh
@@ -24,7 +24,7 @@ if [ ! -f terraform.tfvars ]; then
 	exit 1
 fi
 
-terraform init -upgrade
+terraform init
 
 case "$MODE" in
 app)
@@ -67,7 +67,7 @@ sleep 60
 
 # --- Ansible ---
 echo "==> Kører Ansible playbook..."
-cd "$ANSIBLE_DIR/.."
+cd "$ANSIBLE_DIR/../.."
 
 case "$MODE" in
 app)

--- a/server_go/deploy/spinup.sh
+++ b/server_go/deploy/spinup.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Kør fra server_go-mappen: bash deploy/spinup.sh [app|monitoring|all]
+set -euo pipefail
+
+MODE="${1:-all}"
+
+if [[ "$MODE" != "app" && "$MODE" != "monitoring" && "$MODE" != "all" ]]; then
+  echo "Brug: bash deploy/spinup.sh [app|monitoring|all]"
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TERRAFORM_DIR="$SCRIPT_DIR/terraform"
+ANSIBLE_DIR="$SCRIPT_DIR/ansible"
+INVENTORY="$ANSIBLE_DIR/inventory.yml"
+
+# --- Terraform ---
+echo "==> Initialiserer Terraform..."
+cd "$TERRAFORM_DIR"
+
+if [ ! -f terraform.tfvars ]; then
+  echo "FEJL: $TERRAFORM_DIR/terraform.tfvars mangler."
+  echo "Kopiér terraform.tfvars.example og udfyld værdierne."
+  exit 1
+fi
+
+terraform init -upgrade
+
+case "$MODE" in
+  app)
+    terraform apply -auto-approve \
+      -target=digitalocean_droplet.whoknows \
+      -target=digitalocean_firewall.whoknows \
+      -target=cloudflare_record.whoknows_a
+    APP_IP=$(terraform output -raw droplet_ip)
+    echo "==> App-server IP: $APP_IP"
+    sed -i.bak "/whoknows-vm/{n;s/ansible_host: .*/ansible_host: $APP_IP/}" "$INVENTORY"
+    sed -i.bak "s/server_ip: .*/server_ip: \"$APP_IP\"/" "$INVENTORY"
+    rm -f "$INVENTORY.bak"
+    ;;
+  monitoring)
+    terraform apply -auto-approve \
+      -target=digitalocean_droplet.monitoring \
+      -target=digitalocean_firewall.monitoring \
+      -target=cloudflare_record.monitoring_a
+    MONITORING_IP=$(terraform output -raw monitoring_ip)
+    echo "==> Monitoring-server IP: $MONITORING_IP"
+    sed -i.bak "/monitoring-vm/{n;s/ansible_host: .*/ansible_host: $MONITORING_IP/}" "$INVENTORY"
+    rm -f "$INVENTORY.bak"
+    ;;
+  all)
+    terraform apply -auto-approve
+    APP_IP=$(terraform output -raw droplet_ip)
+    MONITORING_IP=$(terraform output -raw monitoring_ip)
+    echo "==> App-server IP:        $APP_IP"
+    echo "==> Monitoring-server IP: $MONITORING_IP"
+    sed -i.bak "/whoknows-vm/{n;s/ansible_host: .*/ansible_host: $APP_IP/}" "$INVENTORY"
+    sed -i.bak "/monitoring-vm/{n;s/ansible_host: .*/ansible_host: $MONITORING_IP/}" "$INVENTORY"
+    sed -i.bak "s/server_ip: .*/server_ip: \"$APP_IP\"/" "$INVENTORY"
+    rm -f "$INVENTORY.bak"
+    ;;
+esac
+
+# --- Vent på at cloud-init er klar ---
+echo "==> Venter 60 sekunder på at server(e) er klar..."
+sleep 60
+
+# --- Ansible ---
+echo "==> Kører Ansible playbook..."
+cd "$ANSIBLE_DIR/.."
+
+case "$MODE" in
+  app)
+    ansible-playbook deploy/ansible/playbook.yml --limit production
+    echo ""
+    echo "==> Færdig! App:        https://huw.dk ($APP_IP)"
+    ;;
+  monitoring)
+    ansible-playbook deploy/ansible/playbook.yml --limit monitoring
+    echo ""
+    echo "==> Færdig! Monitoring: https://monitor.huw.dk ($MONITORING_IP)"
+    ;;
+  all)
+    ansible-playbook deploy/ansible/playbook.yml
+    echo ""
+    echo "==> Færdig!"
+    echo "    App:        https://huw.dk         ($APP_IP)"
+    echo "    Monitoring: https://monitor.huw.dk ($MONITORING_IP)"
+    ;;
+esac
+
+echo "    DNS er automatisk opdateret af Terraform (Cloudflare)."

--- a/server_go/deploy/terraform/.gitignore
+++ b/server_go/deploy/terraform/.gitignore
@@ -1,0 +1,7 @@
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+terraform.tfvars
+*.tfvars
+!*.tfvars.example

--- a/server_go/deploy/terraform/main.tf
+++ b/server_go/deploy/terraform/main.tf
@@ -1,0 +1,147 @@
+locals {
+  deploy_user_data = <<-EOF
+    #!/bin/bash
+    set -e
+    adduser --disabled-password --gecos "" deploy
+    usermod -aG sudo deploy
+    mkdir -p /home/deploy/.ssh
+    cp /root/.ssh/authorized_keys /home/deploy/.ssh/authorized_keys
+    chown -R deploy:deploy /home/deploy/.ssh
+    chmod 700 /home/deploy/.ssh
+    chmod 600 /home/deploy/.ssh/authorized_keys
+    echo "deploy ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/deploy
+  EOF
+}
+
+data "digitalocean_ssh_key" "deploy" {
+  name = var.ssh_key_name
+}
+
+# ── App server ───────────────────────────────────────────────
+
+resource "digitalocean_droplet" "whoknows" {
+  name      = "whoknows"
+  region    = var.region
+  size      = var.droplet_size
+  image     = "ubuntu-24-04-x64"
+  ssh_keys  = [data.digitalocean_ssh_key.deploy.id]
+  user_data = local.deploy_user_data
+  tags      = ["whoknows"]
+}
+
+resource "cloudflare_record" "whoknows_a" {
+  zone_id = var.cf_zone_id
+  name    = "@"
+  content = digitalocean_droplet.whoknows.ipv4_address
+  type    = "A"
+  ttl     = 1
+  proxied = true
+}
+
+resource "digitalocean_firewall" "whoknows" {
+  name        = "whoknows-firewall"
+  droplet_ids = [digitalocean_droplet.whoknows.id]
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "22"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "80"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "443"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "all"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "all"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "icmp"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+}
+
+# ── Monitoring server ────────────────────────────────────────
+
+resource "digitalocean_droplet" "monitoring" {
+  name      = "whoknows-monitoring"
+  region    = var.region
+  size      = var.monitoring_droplet_size
+  image     = "ubuntu-24-04-x64"
+  ssh_keys  = [data.digitalocean_ssh_key.deploy.id]
+  user_data = local.deploy_user_data
+  tags      = ["whoknows-monitoring"]
+}
+
+resource "cloudflare_record" "monitoring_a" {
+  zone_id = var.cf_zone_id
+  name    = "monitor"
+  content = digitalocean_droplet.monitoring.ipv4_address
+  type    = "A"
+  ttl     = 1
+  proxied = true
+}
+
+resource "digitalocean_firewall" "monitoring" {
+  name        = "whoknows-monitoring-firewall"
+  droplet_ids = [digitalocean_droplet.monitoring.id]
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "22"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "80"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "443"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  # Loki — modtager logs fra Alloy på app-serveren
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "3100"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "all"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "all"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "icmp"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+}

--- a/server_go/deploy/terraform/main.tf
+++ b/server_go/deploy/terraform/main.tf
@@ -125,7 +125,7 @@ resource "digitalocean_firewall" "monitoring" {
   inbound_rule {
     protocol         = "tcp"
     port_range       = "3100"
-    source_addresses = ["0.0.0.0/0", "::/0"]
+    source_addresses = ["${digitalocean_droplet.whoknows.ipv4_address}/32"]
   }
 
   outbound_rule {

--- a/server_go/deploy/terraform/outputs.tf
+++ b/server_go/deploy/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "droplet_ip" {
+  description = "Public IP address of the WhoKnows droplet"
+  value       = digitalocean_droplet.whoknows.ipv4_address
+}
+
+output "droplet_id" {
+  description = "DigitalOcean droplet ID"
+  value       = digitalocean_droplet.whoknows.id
+}
+
+output "dns_record" {
+  description = "Cloudflare A-record der peger på droplet"
+  value       = "${var.domain} → ${digitalocean_droplet.whoknows.ipv4_address}"
+}
+
+output "monitoring_ip" {
+  description = "Public IP address of the monitoring droplet"
+  value       = digitalocean_droplet.monitoring.ipv4_address
+}
+
+output "monitoring_dns_record" {
+  description = "Cloudflare A-record for monitor.huw.dk"
+  value       = "monitor.${var.domain} → ${digitalocean_droplet.monitoring.ipv4_address}"
+}

--- a/server_go/deploy/terraform/terraform.tfvars.example
+++ b/server_go/deploy/terraform/terraform.tfvars.example
@@ -1,0 +1,16 @@
+# Kopiér til terraform.tfvars og udfyld værdier.
+# terraform.tfvars er gitignored — commit den aldrig.
+
+# DigitalOcean
+do_token                = "dop_v1_..."
+ssh_key_name            = "min-noegle"   # navn som det fremgår af: doctl compute ssh-key list
+region                  = "fra1"
+droplet_size            = "s-1vcpu-2gb"
+monitoring_droplet_size = "s-1vcpu-1gb"
+domain                  = "huw.dk"
+
+# Cloudflare DNS
+# API token: Cloudflare Dashboard → My Profile → API Tokens → Edit zone DNS
+# Zone ID:   Cloudflare Dashboard → huw.dk → Overview → Zone ID (højre side)
+cf_api_token = "..."
+cf_zone_id   = "..."

--- a/server_go/deploy/terraform/variables.tf
+++ b/server_go/deploy/terraform/variables.tf
@@ -1,0 +1,45 @@
+variable "do_token" {
+  description = "DigitalOcean API token"
+  type        = string
+  sensitive   = true
+}
+
+variable "ssh_key_name" {
+  description = "Name of SSH key registered in DigitalOcean. Find it with: doctl compute ssh-key list"
+  type        = string
+}
+
+variable "region" {
+  description = "DigitalOcean region"
+  type        = string
+  default     = "fra1"
+}
+
+variable "droplet_size" {
+  description = "Droplet size slug. See: doctl compute size list"
+  type        = string
+  default     = "s-1vcpu-2gb"
+}
+
+variable "domain" {
+  description = "Domain name pointing to the droplet"
+  type        = string
+  default     = "huw.dk"
+}
+
+variable "monitoring_droplet_size" {
+  description = "Droplet size for the monitoring server"
+  type        = string
+  default     = "s-1vcpu-1gb"
+}
+
+variable "cf_api_token" {
+  description = "Cloudflare API token med DNS Edit-rettigheder til zonen. Opret på: Cloudflare Dashboard → My Profile → API Tokens → Edit zone DNS"
+  type        = string
+  sensitive   = true
+}
+
+variable "cf_zone_id" {
+  description = "Cloudflare Zone ID for domænet. Find det på: Cloudflare Dashboard → dit domæne → Overview → Zone ID (højre side)"
+  type        = string
+}

--- a/server_go/deploy/terraform/versions.tf
+++ b/server_go/deploy/terraform/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "digitalocean" {
+  token = var.do_token
+}
+
+provider "cloudflare" {
+  api_token = var.cf_api_token
+}


### PR DESCRIPTION
# Why Was It Necessary
Currently Victor is the hostmaster and if the servers goes down, the rest of the team cant spin up a new one. With implementing terraform, all members off the team can spin up a new whoknows and monitor server and the cloudflare dns will automaticaly be updated to point to the new server.

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated infrastructure provisioning with support for deploying app and monitoring servers independently or together
  * Configured DNS and firewall rules to be automatically set up during deployment

* **Chores**
  * Added deployment configuration files and automation framework setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DevOps-Team36/legacy-whoknows/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->