### PR TITLE
Feat/ansible monitoring

### DIFF
--- a/server_go/deploy/ansible/inventory.yml
+++ b/server_go/deploy/ansible/inventory.yml
@@ -11,9 +11,20 @@ all:
     server_ip: "104.248.138.83"
     certbot_email: "hannibal@ussing.com"
     ansible_user: deploy
+    monitoring_url: monitor.huw.dk
 
   children:
     production:
       hosts:
         whoknows-vm:
           ansible_host: 104.248.138.83
+
+    monitoring:
+      vars:
+        ansible_user: deploy
+        monitoring_dir: /opt/monitoring
+        app_domain: huw.dk
+        grafana_admin_password: "changeme"
+      hosts:
+        monitoring-vm:
+          ansible_host: 147.182.184.189

--- a/server_go/deploy/ansible/playbook.yml
+++ b/server_go/deploy/ansible/playbook.yml
@@ -2,7 +2,7 @@
 # Deploy WhoKnows med Docker Compose.
 # Kør fra server_go: ansible-playbook deploy/ansible/playbook.yml
 - name: Deploy WhoKnows (Docker Compose)
-  hosts: all
+  hosts: production
   become: true
   roles:
     - role: docker
@@ -24,3 +24,12 @@
     - name: Vis deployment-status
       debug:
         msg: "WhoKnows kører på http://{{ ansible_host }}:{{ app_port }}"
+
+- name: Deploy Monitoring Stack
+  hosts: monitoring
+  become: true
+  roles:
+    - role: docker
+      tags: docker,monitoring
+    - role: monitoring
+      tags: monitoring

--- a/server_go/deploy/ansible/roles/monitoring/tasks/main.yml
+++ b/server_go/deploy/ansible/roles/monitoring/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: Opret monitoring-mappe
+  file:
+    path: "{{ monitoring_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Placer docker-compose.yml
+  template:
+    src: docker-compose.yml.j2
+    dest: "{{ monitoring_dir }}/docker-compose.yml"
+    mode: "0644"
+
+- name: Placer Prometheus config
+  template:
+    src: prometheus.yml.j2
+    dest: "{{ monitoring_dir }}/prometheus.yml"
+    mode: "0644"
+
+- name: Placer Loki config
+  template:
+    src: loki-config.yml.j2
+    dest: "{{ monitoring_dir }}/loki-config.yml"
+    mode: "0644"
+
+- name: Start monitoring stack
+  shell: "cd {{ monitoring_dir }} && docker compose up -d"
+  args:
+    executable: /bin/bash

--- a/server_go/deploy/ansible/roles/monitoring/templates/docker-compose.yml.j2
+++ b/server_go/deploy/ansible/roles/monitoring/templates/docker-compose.yml.j2
@@ -1,0 +1,38 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - {{ monitoring_dir }}/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD={{ grafana_admin_password }}
+    volumes:
+      - grafana_data:/var/lib/grafana
+
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    restart: unless-stopped
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/config.yml
+    volumes:
+      - {{ monitoring_dir }}/loki-config.yml:/etc/loki/config.yml:ro
+      - loki_data:/loki
+
+volumes:
+  prometheus_data:
+  grafana_data:
+  loki_data:

--- a/server_go/deploy/ansible/roles/monitoring/templates/loki-config.yml.j2
+++ b/server_go/deploy/ansible/roles/monitoring/templates/loki-config.yml.j2
@@ -1,0 +1,31 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  allow_structured_metadata: false
+
+analytics:
+  reporting_enabled: false

--- a/server_go/deploy/ansible/roles/monitoring/templates/prometheus.yml.j2
+++ b/server_go/deploy/ansible/roles/monitoring/templates/prometheus.yml.j2
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 30s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "whoknows-app"
+    scheme: https
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["{{ app_domain }}"]

--- a/server_go/deploy/ansible/roles/whoknows-app/tasks/main.yml
+++ b/server_go/deploy/ansible/roles/whoknows-app/tasks/main.yml
@@ -10,6 +10,7 @@
     - "{{ app_dir }}"
     - "{{ app_dir }}/pgdata"
     - "{{ app_dir }}/logs"
+    - "{{ app_dir }}/alloy"
 
 - name: Placer docker-compose.yml
   template:
@@ -26,6 +27,14 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: "0600"
+
+- name: Placer Alloy config
+  template:
+    src: config.alloy.j2
+    dest: "{{ app_dir }}/alloy/config.alloy"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: "0644"
 
 - name: Opret active-fil (default blue)
   copy:

--- a/server_go/deploy/ansible/roles/whoknows-app/templates/config.alloy.j2
+++ b/server_go/deploy/ansible/roles/whoknows-app/templates/config.alloy.j2
@@ -1,0 +1,20 @@
+local.file_match "whoknows_search_logs" {
+  path_targets = [
+    {
+      __path__ = "/var/log/whoknows/searches.log",
+      job      = "whoknows-search-logs",
+      app      = "whoknows",
+    },
+  ]
+}
+
+loki.source.file "whoknows_search_logs" {
+  targets    = local.file_match.whoknows_search_logs.targets
+  forward_to = [loki.write.monitoring.receiver]
+}
+
+loki.write "monitoring" {
+  endpoint {
+    url = "http://{{ monitoring_url }}/loki/api/v1/push"
+  }
+}

--- a/server_go/deploy/ansible/roles/whoknows-app/templates/docker-compose.yml.j2
+++ b/server_go/deploy/ansible/roles/whoknows-app/templates/docker-compose.yml.j2
@@ -59,3 +59,14 @@ services:
       timeout: 5s
       retries: 3
       start_period: 20s
+
+  alloy:
+    image: grafana/alloy:latest
+    container_name: alloy
+    restart: unless-stopped
+    volumes:
+      - {{ app_dir }}/alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - {{ app_dir }}/logs:/var/log/whoknows:ro
+    command: run /etc/alloy/config.alloy
+    ports:
+      - "127.0.0.1:12345:12345"

--- a/server_go/deploy/docker-compose.server.yml
+++ b/server_go/deploy/docker-compose.server.yml
@@ -59,3 +59,14 @@ services:
       timeout: 5s
       retries: 3
       start_period: 20s
+
+  alloy:
+    image: grafana/alloy:latest
+    container_name: alloy
+    restart: unless-stopped
+    volumes:
+      - /opt/whoknows/alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - /opt/whoknows/logs:/var/log/whoknows:ro
+    command: run /etc/alloy/config.alloy
+    ports:
+      - "127.0.0.1:12345:12345"


### PR DESCRIPTION
# Why Was It Necessary

Currently the monitor server was not a part of the ansible script, which made it harder to setup, incase the current instance failed. Therefore I added the monitoring server to our ansible scripts, so that each member of the team can easily configure our monitor server. Together with the new terraform implementation, this will provide everyone with the ability to setup both servers.

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change
