### PR TITLE
fix: remove invalid space from search button id attribute

### DIFF
--- a/server_go/templates/search.html
+++ b/server_go/templates/search.html
@@ -11,7 +11,7 @@
       <div class="search-bar">
         <span class="material-symbols-outlined">search</span>
         <input id="search-input" type="text" placeholder="Ask anything, find everything..." value="{{ .Query }}">
-        <button class="btn-search" id="search-button search-input" onclick="makeSearchRequest()">Search</button>
+        <button class="btn-search" id="search-button" onclick="makeSearchRequest()">Search</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Why Was It Necessary

Currently the teachers script is failing, due to our search button having 2 ids and therefore the script cannot find the button.
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal markup structure with no user-facing impact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DevOps-Team36/legacy-whoknows/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->