### PR TITLE
Deploy: fixing html error and making alloy part of the compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ WhoKnows is a search engine for web pages. Users can search for topics and get r
 
 ## Architecture
 
-```
+```text
 User browser
     │
     ▼
@@ -41,36 +41,36 @@ An admin monitors search misses in Grafana, then manually triggers a scrape job 
 
 ## Tech stack
 
-| Layer | Technology |
-|---|---|
-| Backend | Go 1.26, `go-chi/chi` router |
-| Database | PostgreSQL 17, `pgx/v5` driver |
-| Migrations | `pressly/goose` (auto-applied on startup) |
-| Session storage | `gorilla/sessions` cookie store |
-| Scraper | Azure Functions (Node.js), Wikipedia OpenSearch API |
-| Job queue | Azure Storage Queue |
-| Metrics | Prometheus (`prometheus/client_golang`) |
-| Log shipping | Grafana Alloy → Loki |
-| Monitoring | Grafana + Prometheus + Loki on a dedicated server (`monitor.huw.dk`) |
-| Reverse proxy | Nginx with Let's Encrypt TLS |
-| Containerisation | Docker + Docker Compose, blue-green deployment |
-| Infrastructure | DigitalOcean (Terraform), Cloudflare DNS |
-| CI/CD | GitHub Actions (build, test, lint, blue-green deploy) |
-| IaC | Terraform + Ansible |
-| API docs | Swagger / swaggo |
+| Layer            | Technology                                                           |
+| ---------------- | -------------------------------------------------------------------- |
+| Backend          | Go 1.26, `go-chi/chi` router                                         |
+| Database         | PostgreSQL 17, `pgx/v5` driver                                       |
+| Migrations       | `pressly/goose` (auto-applied on startup)                            |
+| Session storage  | `gorilla/sessions` cookie store                                      |
+| Scraper          | Azure Functions (Node.js), Wikipedia OpenSearch API                  |
+| Job queue        | Azure Storage Queue                                                  |
+| Metrics          | Prometheus (`prometheus/client_golang`)                              |
+| Log shipping     | Grafana Alloy → Loki                                                 |
+| Monitoring       | Grafana + Prometheus + Loki on a dedicated server (`monitor.huw.dk`) |
+| Reverse proxy    | Nginx with Let's Encrypt TLS                                         |
+| Containerisation | Docker + Docker Compose, blue-green deployment                       |
+| Infrastructure   | DigitalOcean (Terraform), Cloudflare DNS                             |
+| CI/CD            | GitHub Actions (build, test, lint, blue-green deploy)                |
+| IaC              | Terraform + Ansible                                                  |
+| API docs         | Swagger / swaggo                                                     |
 
 ## API endpoints
 
-| Method | Path | Auth | Description |
-|---|---|---|---|
-| `GET` | `/api/search?q=<query>&language=en` or `da` | — | Search indexed pages |
-| `POST` | `/api/register` | — | Create a user account |
-| `POST` | `/api/login` | — | Log in |
-| `GET` | `/api/logout` | — | Log out |
-| `POST` | `/api/pages` | `WHOKNOWS_SCRAPER_API_KEY` | Ingest a scraped page (used by Azure Function) |
-| `POST` | `/api/scrape` | `WHOKNOWS_SCRAPE_TRIGGER_KEY` | Trigger a scrape job (used by admins) |
-| `GET` | `/metrics` | — | Prometheus metrics |
-| `GET` | `/swagger/*` | — | Swagger UI |
+| Method | Path                                        | Auth                          | Description                                    |
+| ------ | ------------------------------------------- | ----------------------------- | ---------------------------------------------- |
+| `GET`  | `/api/search?q=<query>&language=en` or `da` | —                             | Search indexed pages                           |
+| `POST` | `/api/register`                             | —                             | Create a user account                          |
+| `POST` | `/api/login`                                | —                             | Log in                                         |
+| `GET`  | `/api/logout`                               | —                             | Log out                                        |
+| `POST` | `/api/pages`                                | `WHOKNOWS_SCRAPER_API_KEY`    | Ingest a scraped page (used by Azure Function) |
+| `POST` | `/api/scrape`                               | `WHOKNOWS_SCRAPE_TRIGGER_KEY` | Trigger a scrape job (used by admins)          |
+| `GET`  | `/metrics`                                  | —                             | Prometheus metrics                             |
+| `GET`  | `/swagger/*`                                | —                             | Swagger UI                                     |
 
 ### Triggering a scrape (admin)
 
@@ -135,14 +135,14 @@ Requires `server_go/deploy/terraform/terraform.tfvars` — copy from `terraform.
 
 ## Environment variables
 
-| Variable | Used by | Description |
-|---|---|---|
-| `DATABASE_URL` | Go server | PostgreSQL connection string |
-| `WHOKNOWS_ADDR` | Go server | Bind address (default `0.0.0.0`) |
-| `WHOKNOWS_PORT` | Go server | Port (default `8080`) |
-| `WHOKNOWS_SCRAPER_API_KEY` | Azure Function → `/api/pages` | Auth key for the scraper to submit pages |
-| `WHOKNOWS_SCRAPE_TRIGGER_KEY` | Admin → `/api/scrape` | Auth key for admins to trigger scrape jobs |
-| `WHOKNOWS_SEARCH_LOG_PATH` | Go server | Path for the JSON search log (default `searches.log`) |
+| Variable                      | Used by                       | Description                                           |
+| ----------------------------- | ----------------------------- | ----------------------------------------------------- |
+| `DATABASE_URL`                | Go server                     | PostgreSQL connection string                          |
+| `WHOKNOWS_ADDR`               | Go server                     | Bind address (default `0.0.0.0`)                      |
+| `WHOKNOWS_PORT`               | Go server                     | Port (default `8080`)                                 |
+| `WHOKNOWS_SCRAPER_API_KEY`    | Azure Function → `/api/pages` | Auth key for the scraper to submit pages              |
+| `WHOKNOWS_SCRAPE_TRIGGER_KEY` | Admin → `/api/scrape`         | Auth key for admins to trigger scrape jobs            |
+| `WHOKNOWS_SEARCH_LOG_PATH`    | Go server                     | Path for the JSON search log (default `searches.log`) |
 
 See `.env.example` for a template.
 
@@ -150,23 +150,24 @@ See `.env.example` for a template.
 
 GitHub Actions runs on every push and pull request to `dev`:
 
-| Job | What it checks |
-|---|---|
-| Build & Test | `go build` + `go test` against a live PostgreSQL instance |
-| Migration Sanity Check | `goose up` against a fresh database |
-| Go Lint | `golangci-lint` |
-| Gosec | Static security analysis |
-| Govulncheck | Known CVEs in dependencies |
-| Super-Linter | Dockerfile, YAML, JSON, and other non-Go files |
+| Job                    | What it checks                                            |
+| ---------------------- | --------------------------------------------------------- |
+| Build & Test           | `go build` + `go test` against a live PostgreSQL instance |
+| Migration Sanity Check | `goose up` against a fresh database                       |
+| Go Lint                | `golangci-lint`                                           |
+| Gosec                  | Static security analysis                                  |
+| Govulncheck            | Known CVEs in dependencies                                |
+| Super-Linter           | Dockerfile, YAML, JSON, and other non-Go files            |
 
 ## Scraper
 
 The scraper is an **Azure Function** (Node.js) that runs when a message arrives on the Azure Storage Queue.
 
 Flow:
+
 1. Admin calls `POST /api/scrape` with a query and language.
 2. The Go server pushes a job (`{query, language}`) onto the queue.
 3. The Azure Function reads the message, calls the **Wikipedia OpenSearch API** to find matching article titles, fetches each article's extract, and POSTs each page to `POST /api/pages` on the Go server.
 4. The Go server stores the page in PostgreSQL (`ON CONFLICT DO NOTHING`).
 
-The scraper only indexes Wikipedia content. Queries that have no Wikipedia results (e.g. very specific or non-encyclopaedic topics) will not produce new pages.
+The scraper only indices Wikipedia content. Queries that have no Wikipedia results (e.g. very specific or non-encyclopaedic topics) will not produce new pages.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,172 @@
+# WhoKnows
 
+WhoKnows is a search engine for web pages. Users can search for topics and get relevant results. Content is indexed by a web scraper that fetches pages from Wikipedia and stores them in the database. Searches with no results can be manually forwarded to the scraper by an admin via the Grafana monitoring dashboard.
+
+## Features
+
+- **Search** — full-text search across indexed pages, filtered by language (English/Danish)
+- **User accounts** — register, log in, and log out with session-based authentication
+- **Web scraping** — Wikipedia content indexed via an Azure Function triggered manually by an admin
+- **Prometheus metrics** — HTTP request counts/latency and search hit/miss counters exposed at `/metrics`
+- **Search log** — every search query is written to a JSON log for monitoring in Grafana
+- **API** — JSON endpoints for search, user management, page ingestion, and scrape triggering
+- **Swagger UI** — interactive API docs at `/swagger/`
+
+## Architecture
+
+```
+User browser
+    │
+    ▼
+Nginx (HTTPS, huw.dk)
+    │
+    ▼
+Go HTTP server (chi router, port 8080)
+    │         │
+    │         ▼
+    │     PostgreSQL 17
+    │         (pages, users)
+    │
+    ▼
+Azure Storage Queue  ──►  Azure Function (Node.js)
+                              │
+                              ▼
+                         Wikipedia OpenSearch API
+                              │
+                              ▼
+                         POST /api/pages  (back to Go server)
+```
+
+An admin monitors search misses in Grafana, then manually triggers a scrape job via `POST /api/scrape`. The Go server enqueues the job to an Azure Storage Queue. The Azure Function picks it up, queries Wikipedia, and POSTs the result pages back to `/api/pages`.
+
+## Tech stack
+
+| Layer | Technology |
+|---|---|
+| Backend | Go 1.26, `go-chi/chi` router |
+| Database | PostgreSQL 17, `pgx/v5` driver |
+| Migrations | `pressly/goose` (auto-applied on startup) |
+| Session storage | `gorilla/sessions` cookie store |
+| Scraper | Azure Functions (Node.js), Wikipedia OpenSearch API |
+| Job queue | Azure Storage Queue |
+| Metrics | Prometheus (`prometheus/client_golang`) |
+| Log shipping | Grafana Alloy → Loki |
+| Monitoring | Grafana + Prometheus + Loki on a dedicated server (`monitor.huw.dk`) |
+| Reverse proxy | Nginx with Let's Encrypt TLS |
+| Containerisation | Docker + Docker Compose, blue-green deployment |
+| Infrastructure | DigitalOcean (Terraform), Cloudflare DNS |
+| CI/CD | GitHub Actions (build, test, lint, blue-green deploy) |
+| IaC | Terraform + Ansible |
+| API docs | Swagger / swaggo |
+
+## API endpoints
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `GET` | `/api/search?q=<query>&language=en` or `da` | — | Search indexed pages |
+| `POST` | `/api/register` | — | Create a user account |
+| `POST` | `/api/login` | — | Log in |
+| `GET` | `/api/logout` | — | Log out |
+| `POST` | `/api/pages` | `WHOKNOWS_SCRAPER_API_KEY` | Ingest a scraped page (used by Azure Function) |
+| `POST` | `/api/scrape` | `WHOKNOWS_SCRAPE_TRIGGER_KEY` | Trigger a scrape job (used by admins) |
+| `GET` | `/metrics` | — | Prometheus metrics |
+| `GET` | `/swagger/*` | — | Swagger UI |
+
+### Triggering a scrape (admin)
+
+```bash
+curl -X POST https://huw.dk/api/scrape \
+  -H "X-Scrape-Key: <WHOKNOWS_SCRAPE_TRIGGER_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "Python programming language", "language": "en"}'
+```
+
+## Local development
+
+### Prerequisites
+
+- Go 1.26+
+- Docker + Docker Compose
+
+### Start
+
+```bash
+cd server_go
+cp .env.example .env       # fill in your local values
+docker compose -f docker-compose.dev.yml up -d   # starts PostgreSQL
+go run ./cmd/server
+```
+
+The server starts at `http://localhost:8080`.
+
+### Run tests
+
+```bash
+cd server_go
+go test -v ./...
+```
+
+### Add a migration
+
+```bash
+cd server_go
+goose -dir migrations create <name> sql
+# edit the generated file, then commit — CI validates it, deploy applies it automatically
+```
+
+## Deployment
+
+### Ongoing deploys
+
+Every push to `dev` triggers the GitHub Actions CD pipeline, which does a blue-green deploy to the production server.
+
+### Spinning up a new server
+
+Infrastructure is provisioned with Terraform (DigitalOcean) and configured with Ansible. Cloudflare DNS is updated automatically.
+
+```bash
+cd server_go
+make spinup-app         # app server only (huw.dk)
+make spinup-monitoring  # monitoring server only (monitor.huw.dk)
+make spinup             # both servers from scratch
+```
+
+Requires `server_go/deploy/terraform/terraform.tfvars` — copy from `terraform.tfvars.example` and fill in tokens. See [`server_go/deploy/README.md`](server_go/deploy/README.md) for the full guide.
+
+## Environment variables
+
+| Variable | Used by | Description |
+|---|---|---|
+| `DATABASE_URL` | Go server | PostgreSQL connection string |
+| `WHOKNOWS_ADDR` | Go server | Bind address (default `0.0.0.0`) |
+| `WHOKNOWS_PORT` | Go server | Port (default `8080`) |
+| `WHOKNOWS_SCRAPER_API_KEY` | Azure Function → `/api/pages` | Auth key for the scraper to submit pages |
+| `WHOKNOWS_SCRAPE_TRIGGER_KEY` | Admin → `/api/scrape` | Auth key for admins to trigger scrape jobs |
+| `WHOKNOWS_SEARCH_LOG_PATH` | Go server | Path for the JSON search log (default `searches.log`) |
+
+See `.env.example` for a template.
+
+## CI pipeline
+
+GitHub Actions runs on every push and pull request to `dev`:
+
+| Job | What it checks |
+|---|---|
+| Build & Test | `go build` + `go test` against a live PostgreSQL instance |
+| Migration Sanity Check | `goose up` against a fresh database |
+| Go Lint | `golangci-lint` |
+| Gosec | Static security analysis |
+| Govulncheck | Known CVEs in dependencies |
+| Super-Linter | Dockerfile, YAML, JSON, and other non-Go files |
+
+## Scraper
+
+The scraper is an **Azure Function** (Node.js) that runs when a message arrives on the Azure Storage Queue.
+
+Flow:
+1. Admin calls `POST /api/scrape` with a query and language.
+2. The Go server pushes a job (`{query, language}`) onto the queue.
+3. The Azure Function reads the message, calls the **Wikipedia OpenSearch API** to find matching article titles, fetches each article's extract, and POSTs each page to `POST /api/pages` on the Go server.
+4. The Go server stores the page in PostgreSQL (`ON CONFLICT DO NOTHING`).
+
+The scraper only indexes Wikipedia content. Queries that have no Wikipedia results (e.g. very specific or non-encyclopaedic topics) will not produce new pages.

--- a/server_go/Makefile
+++ b/server_go/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run dev build test lint lint-fix swagger swagger-check clean docker-build docker-up docker-down deploy help
+.PHONY: run dev build test lint lint-fix swagger swagger-check clean docker-build docker-up docker-down deploy spinup spinup-app spinup-monitoring help
 
 BINARY    := whoknows-server
 MAIN      := ./cmd/server
@@ -54,6 +54,15 @@ deploy: ## Deploy to production via Ansible
 
 deploy-check: ## Ansible dry-run (no changes)
 	ansible-playbook deploy/ansible/playbook.yml --check
+
+spinup: ## Spin up begge servere fra scratch (Terraform + DNS + Ansible)
+	bash deploy/spinup.sh all
+
+spinup-app: ## Spin up kun app-server (brug når kun huw.dk er nede)
+	bash deploy/spinup.sh app
+
+spinup-monitoring: ## Spin up kun monitoring-server (brug når monitor.huw.dk er nede)
+	bash deploy/spinup.sh monitoring
 
 # ── Maintenance ─────────────────────────────────────────────
 

--- a/server_go/deploy/ansible/inventory.yml
+++ b/server_go/deploy/ansible/inventory.yml
@@ -11,9 +11,20 @@ all:
     server_ip: "104.248.138.83"
     certbot_email: "hannibal@ussing.com"
     ansible_user: deploy
+    monitoring_url: monitor.huw.dk
 
   children:
     production:
       hosts:
         whoknows-vm:
           ansible_host: 104.248.138.83
+
+    monitoring:
+      vars:
+        ansible_user: deploy
+        monitoring_dir: /opt/monitoring
+        app_domain: huw.dk
+        grafana_admin_password: "changeme"
+      hosts:
+        monitoring-vm:
+          ansible_host: 147.182.184.189

--- a/server_go/deploy/ansible/playbook.yml
+++ b/server_go/deploy/ansible/playbook.yml
@@ -2,7 +2,7 @@
 # Deploy WhoKnows med Docker Compose.
 # Kør fra server_go: ansible-playbook deploy/ansible/playbook.yml
 - name: Deploy WhoKnows (Docker Compose)
-  hosts: all
+  hosts: production
   become: true
   roles:
     - role: docker
@@ -24,3 +24,12 @@
     - name: Vis deployment-status
       debug:
         msg: "WhoKnows kører på http://{{ ansible_host }}:{{ app_port }}"
+
+- name: Deploy Monitoring Stack
+  hosts: monitoring
+  become: true
+  roles:
+    - role: docker
+      tags: docker,monitoring
+    - role: monitoring
+      tags: monitoring

--- a/server_go/deploy/ansible/roles/monitoring/tasks/main.yml
+++ b/server_go/deploy/ansible/roles/monitoring/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: Opret monitoring-mappe
+  file:
+    path: "{{ monitoring_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Placer docker-compose.yml
+  template:
+    src: docker-compose.yml.j2
+    dest: "{{ monitoring_dir }}/docker-compose.yml"
+    mode: "0644"
+
+- name: Placer Prometheus config
+  template:
+    src: prometheus.yml.j2
+    dest: "{{ monitoring_dir }}/prometheus.yml"
+    mode: "0644"
+
+- name: Placer Loki config
+  template:
+    src: loki-config.yml.j2
+    dest: "{{ monitoring_dir }}/loki-config.yml"
+    mode: "0644"
+
+- name: Start monitoring stack
+  shell: "cd {{ monitoring_dir }} && docker compose up -d"
+  args:
+    executable: /bin/bash

--- a/server_go/deploy/ansible/roles/monitoring/templates/docker-compose.yml.j2
+++ b/server_go/deploy/ansible/roles/monitoring/templates/docker-compose.yml.j2
@@ -1,0 +1,38 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - {{ monitoring_dir }}/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD={{ grafana_admin_password }}
+    volumes:
+      - grafana_data:/var/lib/grafana
+
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    restart: unless-stopped
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/config.yml
+    volumes:
+      - {{ monitoring_dir }}/loki-config.yml:/etc/loki/config.yml:ro
+      - loki_data:/loki
+
+volumes:
+  prometheus_data:
+  grafana_data:
+  loki_data:

--- a/server_go/deploy/ansible/roles/monitoring/templates/loki-config.yml.j2
+++ b/server_go/deploy/ansible/roles/monitoring/templates/loki-config.yml.j2
@@ -1,0 +1,31 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  allow_structured_metadata: false
+
+analytics:
+  reporting_enabled: false

--- a/server_go/deploy/ansible/roles/monitoring/templates/prometheus.yml.j2
+++ b/server_go/deploy/ansible/roles/monitoring/templates/prometheus.yml.j2
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 30s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "whoknows-app"
+    scheme: https
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["{{ app_domain }}"]

--- a/server_go/deploy/ansible/roles/whoknows-app/tasks/main.yml
+++ b/server_go/deploy/ansible/roles/whoknows-app/tasks/main.yml
@@ -10,6 +10,7 @@
     - "{{ app_dir }}"
     - "{{ app_dir }}/pgdata"
     - "{{ app_dir }}/logs"
+    - "{{ app_dir }}/alloy"
 
 - name: Placer docker-compose.yml
   template:
@@ -26,6 +27,14 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: "0600"
+
+- name: Placer Alloy config
+  template:
+    src: config.alloy.j2
+    dest: "{{ app_dir }}/alloy/config.alloy"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: "0644"
 
 - name: Opret active-fil (default blue)
   copy:

--- a/server_go/deploy/ansible/roles/whoknows-app/templates/config.alloy.j2
+++ b/server_go/deploy/ansible/roles/whoknows-app/templates/config.alloy.j2
@@ -1,0 +1,20 @@
+local.file_match "whoknows_search_logs" {
+  path_targets = [
+    {
+      __path__ = "/var/log/whoknows/searches.log",
+      job      = "whoknows-search-logs",
+      app      = "whoknows",
+    },
+  ]
+}
+
+loki.source.file "whoknows_search_logs" {
+  targets    = local.file_match.whoknows_search_logs.targets
+  forward_to = [loki.write.monitoring.receiver]
+}
+
+loki.write "monitoring" {
+  endpoint {
+    url = "http://{{ monitoring_url }}/loki/api/v1/push"
+  }
+}

--- a/server_go/deploy/ansible/roles/whoknows-app/templates/docker-compose.yml.j2
+++ b/server_go/deploy/ansible/roles/whoknows-app/templates/docker-compose.yml.j2
@@ -59,3 +59,14 @@ services:
       timeout: 5s
       retries: 3
       start_period: 20s
+
+  alloy:
+    image: grafana/alloy:latest
+    container_name: alloy
+    restart: unless-stopped
+    volumes:
+      - {{ app_dir }}/alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - {{ app_dir }}/logs:/var/log/whoknows:ro
+    command: run /etc/alloy/config.alloy
+    ports:
+      - "127.0.0.1:12345:12345"

--- a/server_go/deploy/docker-compose.server.yml
+++ b/server_go/deploy/docker-compose.server.yml
@@ -59,3 +59,14 @@ services:
       timeout: 5s
       retries: 3
       start_period: 20s
+
+  alloy:
+    image: grafana/alloy:latest
+    container_name: alloy
+    restart: unless-stopped
+    volumes:
+      - /opt/whoknows/alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - /opt/whoknows/logs:/var/log/whoknows:ro
+    command: run /etc/alloy/config.alloy
+    ports:
+      - "127.0.0.1:12345:12345"

--- a/server_go/deploy/spinup.sh
+++ b/server_go/deploy/spinup.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 MODE="${1:-all}"
 
 if [[ "$MODE" != "app" && "$MODE" != "monitoring" && "$MODE" != "all" ]]; then
-  echo "Brug: bash deploy/spinup.sh [app|monitoring|all]"
-  exit 1
+    echo "Brug: bash deploy/spinup.sh [app|monitoring|all]"
+    exit 1
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -19,36 +19,36 @@ echo "==> Initialiserer Terraform..."
 cd "$TERRAFORM_DIR"
 
 if [ ! -f terraform.tfvars ]; then
-  echo "FEJL: $TERRAFORM_DIR/terraform.tfvars mangler."
-  echo "Kopiér terraform.tfvars.example og udfyld værdierne."
-  exit 1
+    echo "FEJL: $TERRAFORM_DIR/terraform.tfvars mangler."
+    echo "Kopiér terraform.tfvars.example og udfyld værdierne."
+    exit 1
 fi
 
 terraform init -upgrade
 
 case "$MODE" in
-  app)
+app)
     terraform apply -auto-approve \
-      -target=digitalocean_droplet.whoknows \
-      -target=digitalocean_firewall.whoknows \
-      -target=cloudflare_record.whoknows_a
+        -target=digitalocean_droplet.whoknows \
+        -target=digitalocean_firewall.whoknows \
+        -target=cloudflare_record.whoknows_a
     APP_IP=$(terraform output -raw droplet_ip)
     echo "==> App-server IP: $APP_IP"
     sed -i.bak "/whoknows-vm/{n;s/ansible_host: .*/ansible_host: $APP_IP/}" "$INVENTORY"
     sed -i.bak "s/server_ip: .*/server_ip: \"$APP_IP\"/" "$INVENTORY"
     rm -f "$INVENTORY.bak"
     ;;
-  monitoring)
+monitoring)
     terraform apply -auto-approve \
-      -target=digitalocean_droplet.monitoring \
-      -target=digitalocean_firewall.monitoring \
-      -target=cloudflare_record.monitoring_a
+        -target=digitalocean_droplet.monitoring \
+        -target=digitalocean_firewall.monitoring \
+        -target=cloudflare_record.monitoring_a
     MONITORING_IP=$(terraform output -raw monitoring_ip)
     echo "==> Monitoring-server IP: $MONITORING_IP"
     sed -i.bak "/monitoring-vm/{n;s/ansible_host: .*/ansible_host: $MONITORING_IP/}" "$INVENTORY"
     rm -f "$INVENTORY.bak"
     ;;
-  all)
+all)
     terraform apply -auto-approve
     APP_IP=$(terraform output -raw droplet_ip)
     MONITORING_IP=$(terraform output -raw monitoring_ip)
@@ -70,17 +70,17 @@ echo "==> Kører Ansible playbook..."
 cd "$ANSIBLE_DIR/.."
 
 case "$MODE" in
-  app)
+app)
     ansible-playbook deploy/ansible/playbook.yml --limit production
     echo ""
     echo "==> Færdig! App:        https://huw.dk ($APP_IP)"
     ;;
-  monitoring)
+monitoring)
     ansible-playbook deploy/ansible/playbook.yml --limit monitoring
     echo ""
     echo "==> Færdig! Monitoring: https://monitor.huw.dk ($MONITORING_IP)"
     ;;
-  all)
+all)
     ansible-playbook deploy/ansible/playbook.yml
     echo ""
     echo "==> Færdig!"

--- a/server_go/deploy/spinup.sh
+++ b/server_go/deploy/spinup.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 MODE="${1:-all}"
 
 if [[ "$MODE" != "app" && "$MODE" != "monitoring" && "$MODE" != "all" ]]; then
-    echo "Brug: bash deploy/spinup.sh [app|monitoring|all]"
-    exit 1
+	echo "Brug: bash deploy/spinup.sh [app|monitoring|all]"
+	exit 1
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -19,46 +19,46 @@ echo "==> Initialiserer Terraform..."
 cd "$TERRAFORM_DIR"
 
 if [ ! -f terraform.tfvars ]; then
-    echo "FEJL: $TERRAFORM_DIR/terraform.tfvars mangler."
-    echo "Kopiér terraform.tfvars.example og udfyld værdierne."
-    exit 1
+	echo "FEJL: $TERRAFORM_DIR/terraform.tfvars mangler."
+	echo "Kopiér terraform.tfvars.example og udfyld værdierne."
+	exit 1
 fi
 
 terraform init -upgrade
 
 case "$MODE" in
 app)
-    terraform apply -auto-approve \
-        -target=digitalocean_droplet.whoknows \
-        -target=digitalocean_firewall.whoknows \
-        -target=cloudflare_record.whoknows_a
-    APP_IP=$(terraform output -raw droplet_ip)
-    echo "==> App-server IP: $APP_IP"
-    sed -i.bak "/whoknows-vm/{n;s/ansible_host: .*/ansible_host: $APP_IP/}" "$INVENTORY"
-    sed -i.bak "s/server_ip: .*/server_ip: \"$APP_IP\"/" "$INVENTORY"
-    rm -f "$INVENTORY.bak"
-    ;;
+	terraform apply -auto-approve \
+		-target=digitalocean_droplet.whoknows \
+		-target=digitalocean_firewall.whoknows \
+		-target=cloudflare_record.whoknows_a
+	APP_IP=$(terraform output -raw droplet_ip)
+	echo "==> App-server IP: $APP_IP"
+	sed -i.bak "/whoknows-vm/{n;s/ansible_host: .*/ansible_host: $APP_IP/}" "$INVENTORY"
+	sed -i.bak "s/server_ip: .*/server_ip: \"$APP_IP\"/" "$INVENTORY"
+	rm -f "$INVENTORY.bak"
+	;;
 monitoring)
-    terraform apply -auto-approve \
-        -target=digitalocean_droplet.monitoring \
-        -target=digitalocean_firewall.monitoring \
-        -target=cloudflare_record.monitoring_a
-    MONITORING_IP=$(terraform output -raw monitoring_ip)
-    echo "==> Monitoring-server IP: $MONITORING_IP"
-    sed -i.bak "/monitoring-vm/{n;s/ansible_host: .*/ansible_host: $MONITORING_IP/}" "$INVENTORY"
-    rm -f "$INVENTORY.bak"
-    ;;
+	terraform apply -auto-approve \
+		-target=digitalocean_droplet.monitoring \
+		-target=digitalocean_firewall.monitoring \
+		-target=cloudflare_record.monitoring_a
+	MONITORING_IP=$(terraform output -raw monitoring_ip)
+	echo "==> Monitoring-server IP: $MONITORING_IP"
+	sed -i.bak "/monitoring-vm/{n;s/ansible_host: .*/ansible_host: $MONITORING_IP/}" "$INVENTORY"
+	rm -f "$INVENTORY.bak"
+	;;
 all)
-    terraform apply -auto-approve
-    APP_IP=$(terraform output -raw droplet_ip)
-    MONITORING_IP=$(terraform output -raw monitoring_ip)
-    echo "==> App-server IP:        $APP_IP"
-    echo "==> Monitoring-server IP: $MONITORING_IP"
-    sed -i.bak "/whoknows-vm/{n;s/ansible_host: .*/ansible_host: $APP_IP/}" "$INVENTORY"
-    sed -i.bak "/monitoring-vm/{n;s/ansible_host: .*/ansible_host: $MONITORING_IP/}" "$INVENTORY"
-    sed -i.bak "s/server_ip: .*/server_ip: \"$APP_IP\"/" "$INVENTORY"
-    rm -f "$INVENTORY.bak"
-    ;;
+	terraform apply -auto-approve
+	APP_IP=$(terraform output -raw droplet_ip)
+	MONITORING_IP=$(terraform output -raw monitoring_ip)
+	echo "==> App-server IP:        $APP_IP"
+	echo "==> Monitoring-server IP: $MONITORING_IP"
+	sed -i.bak "/whoknows-vm/{n;s/ansible_host: .*/ansible_host: $APP_IP/}" "$INVENTORY"
+	sed -i.bak "/monitoring-vm/{n;s/ansible_host: .*/ansible_host: $MONITORING_IP/}" "$INVENTORY"
+	sed -i.bak "s/server_ip: .*/server_ip: \"$APP_IP\"/" "$INVENTORY"
+	rm -f "$INVENTORY.bak"
+	;;
 esac
 
 # --- Vent på at cloud-init er klar ---
@@ -71,22 +71,22 @@ cd "$ANSIBLE_DIR/.."
 
 case "$MODE" in
 app)
-    ansible-playbook deploy/ansible/playbook.yml --limit production
-    echo ""
-    echo "==> Færdig! App:        https://huw.dk ($APP_IP)"
-    ;;
+	ansible-playbook deploy/ansible/playbook.yml --limit production
+	echo ""
+	echo "==> Færdig! App:        https://huw.dk ($APP_IP)"
+	;;
 monitoring)
-    ansible-playbook deploy/ansible/playbook.yml --limit monitoring
-    echo ""
-    echo "==> Færdig! Monitoring: https://monitor.huw.dk ($MONITORING_IP)"
-    ;;
+	ansible-playbook deploy/ansible/playbook.yml --limit monitoring
+	echo ""
+	echo "==> Færdig! Monitoring: https://monitor.huw.dk ($MONITORING_IP)"
+	;;
 all)
-    ansible-playbook deploy/ansible/playbook.yml
-    echo ""
-    echo "==> Færdig!"
-    echo "    App:        https://huw.dk         ($APP_IP)"
-    echo "    Monitoring: https://monitor.huw.dk ($MONITORING_IP)"
-    ;;
+	ansible-playbook deploy/ansible/playbook.yml
+	echo ""
+	echo "==> Færdig!"
+	echo "    App:        https://huw.dk         ($APP_IP)"
+	echo "    Monitoring: https://monitor.huw.dk ($MONITORING_IP)"
+	;;
 esac
 
 echo "    DNS er automatisk opdateret af Terraform (Cloudflare)."

--- a/server_go/deploy/spinup.sh
+++ b/server_go/deploy/spinup.sh
@@ -24,7 +24,7 @@ if [ ! -f terraform.tfvars ]; then
 	exit 1
 fi
 
-terraform init -upgrade
+terraform init
 
 case "$MODE" in
 app)
@@ -67,7 +67,7 @@ sleep 60
 
 # --- Ansible ---
 echo "==> Kører Ansible playbook..."
-cd "$ANSIBLE_DIR/.."
+cd "$ANSIBLE_DIR/../.."
 
 case "$MODE" in
 app)

--- a/server_go/deploy/spinup.sh
+++ b/server_go/deploy/spinup.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Kør fra server_go-mappen: bash deploy/spinup.sh [app|monitoring|all]
+set -euo pipefail
+
+MODE="${1:-all}"
+
+if [[ "$MODE" != "app" && "$MODE" != "monitoring" && "$MODE" != "all" ]]; then
+  echo "Brug: bash deploy/spinup.sh [app|monitoring|all]"
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TERRAFORM_DIR="$SCRIPT_DIR/terraform"
+ANSIBLE_DIR="$SCRIPT_DIR/ansible"
+INVENTORY="$ANSIBLE_DIR/inventory.yml"
+
+# --- Terraform ---
+echo "==> Initialiserer Terraform..."
+cd "$TERRAFORM_DIR"
+
+if [ ! -f terraform.tfvars ]; then
+  echo "FEJL: $TERRAFORM_DIR/terraform.tfvars mangler."
+  echo "Kopiér terraform.tfvars.example og udfyld værdierne."
+  exit 1
+fi
+
+terraform init -upgrade
+
+case "$MODE" in
+  app)
+    terraform apply -auto-approve \
+      -target=digitalocean_droplet.whoknows \
+      -target=digitalocean_firewall.whoknows \
+      -target=cloudflare_record.whoknows_a
+    APP_IP=$(terraform output -raw droplet_ip)
+    echo "==> App-server IP: $APP_IP"
+    sed -i.bak "/whoknows-vm/{n;s/ansible_host: .*/ansible_host: $APP_IP/}" "$INVENTORY"
+    sed -i.bak "s/server_ip: .*/server_ip: \"$APP_IP\"/" "$INVENTORY"
+    rm -f "$INVENTORY.bak"
+    ;;
+  monitoring)
+    terraform apply -auto-approve \
+      -target=digitalocean_droplet.monitoring \
+      -target=digitalocean_firewall.monitoring \
+      -target=cloudflare_record.monitoring_a
+    MONITORING_IP=$(terraform output -raw monitoring_ip)
+    echo "==> Monitoring-server IP: $MONITORING_IP"
+    sed -i.bak "/monitoring-vm/{n;s/ansible_host: .*/ansible_host: $MONITORING_IP/}" "$INVENTORY"
+    rm -f "$INVENTORY.bak"
+    ;;
+  all)
+    terraform apply -auto-approve
+    APP_IP=$(terraform output -raw droplet_ip)
+    MONITORING_IP=$(terraform output -raw monitoring_ip)
+    echo "==> App-server IP:        $APP_IP"
+    echo "==> Monitoring-server IP: $MONITORING_IP"
+    sed -i.bak "/whoknows-vm/{n;s/ansible_host: .*/ansible_host: $APP_IP/}" "$INVENTORY"
+    sed -i.bak "/monitoring-vm/{n;s/ansible_host: .*/ansible_host: $MONITORING_IP/}" "$INVENTORY"
+    sed -i.bak "s/server_ip: .*/server_ip: \"$APP_IP\"/" "$INVENTORY"
+    rm -f "$INVENTORY.bak"
+    ;;
+esac
+
+# --- Vent på at cloud-init er klar ---
+echo "==> Venter 60 sekunder på at server(e) er klar..."
+sleep 60
+
+# --- Ansible ---
+echo "==> Kører Ansible playbook..."
+cd "$ANSIBLE_DIR/.."
+
+case "$MODE" in
+  app)
+    ansible-playbook deploy/ansible/playbook.yml --limit production
+    echo ""
+    echo "==> Færdig! App:        https://huw.dk ($APP_IP)"
+    ;;
+  monitoring)
+    ansible-playbook deploy/ansible/playbook.yml --limit monitoring
+    echo ""
+    echo "==> Færdig! Monitoring: https://monitor.huw.dk ($MONITORING_IP)"
+    ;;
+  all)
+    ansible-playbook deploy/ansible/playbook.yml
+    echo ""
+    echo "==> Færdig!"
+    echo "    App:        https://huw.dk         ($APP_IP)"
+    echo "    Monitoring: https://monitor.huw.dk ($MONITORING_IP)"
+    ;;
+esac
+
+echo "    DNS er automatisk opdateret af Terraform (Cloudflare)."

--- a/server_go/deploy/terraform/.gitignore
+++ b/server_go/deploy/terraform/.gitignore
@@ -1,0 +1,7 @@
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+terraform.tfvars
+*.tfvars
+!*.tfvars.example

--- a/server_go/deploy/terraform/main.tf
+++ b/server_go/deploy/terraform/main.tf
@@ -1,0 +1,147 @@
+locals {
+  deploy_user_data = <<-EOF
+    #!/bin/bash
+    set -e
+    adduser --disabled-password --gecos "" deploy
+    usermod -aG sudo deploy
+    mkdir -p /home/deploy/.ssh
+    cp /root/.ssh/authorized_keys /home/deploy/.ssh/authorized_keys
+    chown -R deploy:deploy /home/deploy/.ssh
+    chmod 700 /home/deploy/.ssh
+    chmod 600 /home/deploy/.ssh/authorized_keys
+    echo "deploy ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/deploy
+  EOF
+}
+
+data "digitalocean_ssh_key" "deploy" {
+  name = var.ssh_key_name
+}
+
+# ── App server ───────────────────────────────────────────────
+
+resource "digitalocean_droplet" "whoknows" {
+  name      = "whoknows"
+  region    = var.region
+  size      = var.droplet_size
+  image     = "ubuntu-24-04-x64"
+  ssh_keys  = [data.digitalocean_ssh_key.deploy.id]
+  user_data = local.deploy_user_data
+  tags      = ["whoknows"]
+}
+
+resource "cloudflare_record" "whoknows_a" {
+  zone_id = var.cf_zone_id
+  name    = "@"
+  content = digitalocean_droplet.whoknows.ipv4_address
+  type    = "A"
+  ttl     = 1
+  proxied = true
+}
+
+resource "digitalocean_firewall" "whoknows" {
+  name        = "whoknows-firewall"
+  droplet_ids = [digitalocean_droplet.whoknows.id]
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "22"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "80"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "443"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "all"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "all"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "icmp"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+}
+
+# ── Monitoring server ────────────────────────────────────────
+
+resource "digitalocean_droplet" "monitoring" {
+  name      = "whoknows-monitoring"
+  region    = var.region
+  size      = var.monitoring_droplet_size
+  image     = "ubuntu-24-04-x64"
+  ssh_keys  = [data.digitalocean_ssh_key.deploy.id]
+  user_data = local.deploy_user_data
+  tags      = ["whoknows-monitoring"]
+}
+
+resource "cloudflare_record" "monitoring_a" {
+  zone_id = var.cf_zone_id
+  name    = "monitor"
+  content = digitalocean_droplet.monitoring.ipv4_address
+  type    = "A"
+  ttl     = 1
+  proxied = true
+}
+
+resource "digitalocean_firewall" "monitoring" {
+  name        = "whoknows-monitoring-firewall"
+  droplet_ids = [digitalocean_droplet.monitoring.id]
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "22"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "80"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "443"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  # Loki — modtager logs fra Alloy på app-serveren
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "3100"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "all"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "all"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "icmp"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+}

--- a/server_go/deploy/terraform/main.tf
+++ b/server_go/deploy/terraform/main.tf
@@ -125,7 +125,7 @@ resource "digitalocean_firewall" "monitoring" {
   inbound_rule {
     protocol         = "tcp"
     port_range       = "3100"
-    source_addresses = ["0.0.0.0/0", "::/0"]
+    source_addresses = ["${digitalocean_droplet.whoknows.ipv4_address}/32"]
   }
 
   outbound_rule {

--- a/server_go/deploy/terraform/outputs.tf
+++ b/server_go/deploy/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "droplet_ip" {
+  description = "Public IP address of the WhoKnows droplet"
+  value       = digitalocean_droplet.whoknows.ipv4_address
+}
+
+output "droplet_id" {
+  description = "DigitalOcean droplet ID"
+  value       = digitalocean_droplet.whoknows.id
+}
+
+output "dns_record" {
+  description = "Cloudflare A-record der peger på droplet"
+  value       = "${var.domain} → ${digitalocean_droplet.whoknows.ipv4_address}"
+}
+
+output "monitoring_ip" {
+  description = "Public IP address of the monitoring droplet"
+  value       = digitalocean_droplet.monitoring.ipv4_address
+}
+
+output "monitoring_dns_record" {
+  description = "Cloudflare A-record for monitor.huw.dk"
+  value       = "monitor.${var.domain} → ${digitalocean_droplet.monitoring.ipv4_address}"
+}

--- a/server_go/deploy/terraform/terraform.tfvars.example
+++ b/server_go/deploy/terraform/terraform.tfvars.example
@@ -1,0 +1,16 @@
+# Kopiér til terraform.tfvars og udfyld værdier.
+# terraform.tfvars er gitignored — commit den aldrig.
+
+# DigitalOcean
+do_token                = "dop_v1_..."
+ssh_key_name            = "min-noegle"   # navn som det fremgår af: doctl compute ssh-key list
+region                  = "fra1"
+droplet_size            = "s-1vcpu-2gb"
+monitoring_droplet_size = "s-1vcpu-1gb"
+domain                  = "huw.dk"
+
+# Cloudflare DNS
+# API token: Cloudflare Dashboard → My Profile → API Tokens → Edit zone DNS
+# Zone ID:   Cloudflare Dashboard → huw.dk → Overview → Zone ID (højre side)
+cf_api_token = "..."
+cf_zone_id   = "..."

--- a/server_go/deploy/terraform/variables.tf
+++ b/server_go/deploy/terraform/variables.tf
@@ -1,0 +1,45 @@
+variable "do_token" {
+  description = "DigitalOcean API token"
+  type        = string
+  sensitive   = true
+}
+
+variable "ssh_key_name" {
+  description = "Name of SSH key registered in DigitalOcean. Find it with: doctl compute ssh-key list"
+  type        = string
+}
+
+variable "region" {
+  description = "DigitalOcean region"
+  type        = string
+  default     = "fra1"
+}
+
+variable "droplet_size" {
+  description = "Droplet size slug. See: doctl compute size list"
+  type        = string
+  default     = "s-1vcpu-2gb"
+}
+
+variable "domain" {
+  description = "Domain name pointing to the droplet"
+  type        = string
+  default     = "huw.dk"
+}
+
+variable "monitoring_droplet_size" {
+  description = "Droplet size for the monitoring server"
+  type        = string
+  default     = "s-1vcpu-1gb"
+}
+
+variable "cf_api_token" {
+  description = "Cloudflare API token med DNS Edit-rettigheder til zonen. Opret på: Cloudflare Dashboard → My Profile → API Tokens → Edit zone DNS"
+  type        = string
+  sensitive   = true
+}
+
+variable "cf_zone_id" {
+  description = "Cloudflare Zone ID for domænet. Find det på: Cloudflare Dashboard → dit domæne → Overview → Zone ID (højre side)"
+  type        = string
+}

--- a/server_go/deploy/terraform/versions.tf
+++ b/server_go/deploy/terraform/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "digitalocean" {
+  token = var.do_token
+}
+
+provider "cloudflare" {
+  api_token = var.cf_api_token
+}

--- a/server_go/templates/search.html
+++ b/server_go/templates/search.html
@@ -11,7 +11,7 @@
       <div class="search-bar">
         <span class="material-symbols-outlined">search</span>
         <input id="search-input" type="text" placeholder="Ask anything, find everything..." value="{{ .Query }}">
-        <button class="btn-search" id="search-button search-input" onclick="makeSearchRequest()">Search</button>
+        <button class="btn-search" id="search-button" onclick="makeSearchRequest()">Search</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Why Was It Necessary

Currently the teachers script is failing due to our search button having 2 ids, this has been fixed. 
The current alloy container was started from inside the server, instead of being added as a container in the compose, this has been fixed now.
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change
