### PR TITLE
Deploy: add alloy to deployment script

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,6 +45,7 @@ jobs:
 
             docker compose pull "whoknows-$NEW"
             docker compose up -d "whoknows-$NEW"
+            docker compose up -d alloy
 
             HEALTHY=false
             for i in $(seq 1 30); do


### PR DESCRIPTION
# Why Was It Necessary

I forgot to add the alloy to the deployment workflow
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change
