### PR TITLE
fix: mount logs volume so searches are visible to alloy

### DIFF
--- a/server_go/deploy/ansible/roles/whoknows-app/templates/docker-compose.yml.j2
+++ b/server_go/deploy/ansible/roles/whoknows-app/templates/docker-compose.yml.j2
@@ -36,6 +36,8 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     env_file: .env
+    volumes:
+      - {{ app_dir }}/logs:/app/logs
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/"]
       interval: 10s
@@ -53,6 +55,8 @@ services:
     ports:
       - "127.0.0.1:8081:8080"
     env_file: .env
+    volumes:
+      - {{ app_dir }}/logs:/app/logs
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/"]
       interval: 10s

--- a/server_go/deploy/docker-compose.server.yml
+++ b/server_go/deploy/docker-compose.server.yml
@@ -36,6 +36,8 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     env_file: .env
+    volumes:
+      - /opt/whoknows/logs:/app/logs
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/"]
       interval: 10s
@@ -53,6 +55,8 @@ services:
     ports:
       - "127.0.0.1:8081:8080"
     env_file: .env
+    volumes:
+      - /opt/whoknows/logs:/app/logs
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/"]
       interval: 10s


### PR DESCRIPTION
# Why Was It Necessary

The current containers on the server doenst have a volume for the logs, therefore its not getting saved. 
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added shared log directory mounting to application services in deployment configuration.
  * Updated service instances to include host directory volume mount mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DevOps-Team36/legacy-whoknows/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->