### PR TITLE
Deploy: fix logs volume mount

### DIFF
--- a/server_go/deploy/ansible/roles/whoknows-app/templates/docker-compose.yml.j2
+++ b/server_go/deploy/ansible/roles/whoknows-app/templates/docker-compose.yml.j2
@@ -36,6 +36,8 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     env_file: .env
+    volumes:
+      - {{ app_dir }}/logs:/app/logs
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/"]
       interval: 10s
@@ -53,6 +55,8 @@ services:
     ports:
       - "127.0.0.1:8081:8080"
     env_file: .env
+    volumes:
+      - {{ app_dir }}/logs:/app/logs
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/"]
       interval: 10s

--- a/server_go/deploy/docker-compose.server.yml
+++ b/server_go/deploy/docker-compose.server.yml
@@ -36,6 +36,8 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     env_file: .env
+    volumes:
+      - /opt/whoknows/logs:/app/logs
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/"]
       interval: 10s
@@ -53,6 +55,8 @@ services:
     ports:
       - "127.0.0.1:8081:8080"
     env_file: .env
+    volumes:
+      - /opt/whoknows/logs:/app/logs
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/"]
       interval: 10s


### PR DESCRIPTION
# Why Was It Necessary

The current compose file doesnt have a volume mount for the applications logs, this has been fixed in this pr.
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change
