### PR TITLE
fix: add workflow_dispatch to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,6 +2,7 @@ name: Deploy
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
# Why Was It Necessary

Incase of a production error, this pr implements a workflow dispatch to the deploy workflow, so we could set an earlier image as latest and then redeploy that image in order to fix the production.
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow to support manual triggering alongside existing automated triggers. This provides teams with greater operational flexibility, enabling on-demand deployment execution when needed while maintaining all existing automated workflow mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DevOps-Team36/legacy-whoknows/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->