### PR TITLE
Feat/security and monitoring improvements

### DIFF
--- a/server_go/deploy/ansible/inventory.yml
+++ b/server_go/deploy/ansible/inventory.yml
@@ -12,6 +12,10 @@ all:
     certbot_email: "hannibal@ussing.com"
     ansible_user: deploy
     monitoring_url: monitor.huw.dk
+    ssh_authorized_keys:
+      - "ssh-ed25519 CHANGEME member1-navn"
+      - "ssh-ed25519 CHANGEME member2-navn"
+      - "ssh-ed25519 CHANGEME member3-navn"
 
   children:
     production:

--- a/server_go/deploy/ansible/inventory.yml
+++ b/server_go/deploy/ansible/inventory.yml
@@ -13,9 +13,18 @@ all:
     ansible_user: deploy
     monitoring_url: monitor.huw.dk
     ssh_authorized_keys:
-      - "ssh-ed25519 CHANGEME member1-navn"
-      - "ssh-ed25519 CHANGEME member2-navn"
-      - "ssh-ed25519 CHANGEME member3-navn"
+      # monneDev
+      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAYhfzEUJ1gnSnj/6mwvUKMXH0ePgm2W7X6TjrMMfqUl"
+      - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC2m+5RJqzvb2G8CRo2/kF0gNOAMf2yU2O3ZjGMJ5xCEZc7CjDyJtqk4TlRS03bWeth5lchX0+y9LegeoO9efAqHWKDtXHoMVbPiy7kb9RVq5djtBQcCXTRlJHBtiTsTmavDHvkPhH+95NKBF5lcMMrTqHpnHiMLmEq9k7Uc70VeS5wgpEcWwOFGh/BbXhXG45mn23mpeQdf8POMD+mp+xR8OL06YP9JdSnkljqXkSXsVbD+Vm1LueZ06xUp5tMQjqTNFF11XUiS+SGbH8Jq6rNJMGv441CV2K0hYO744vckMPSmlbuihh76lEbhvlN361lZKkF81qbSFjCdPo1XkPzvzF44ENQFpm9Hn0Ol8oUTOKqF12minq6epQF8zvj/ox7Q9HvFllnJzYnnDCDVKeTsj7m6pJ4HZMZYsaWlPne2/k59PkH54dkRdXzXvbjYG0HaDWWRO3KiCxSRIIfY7xjemF/3c0kxhldUKW70ZNKH44FcXIpcWbj1tqP+1cM7KuzV/odsm48C3o4E2M+aM0/bt3d9YqCjYDyykDyShxSLgNKjtV0COPlMAYE8wUwXZzivjXNyXhbKjQ+uFPSAPCVt2x9tFvD2X0g6EKs6gMLb35B78AV5hSSNgZ8B6M8oHehRTwFIM9lODuyv7nVSHRgvaGoPSfmVxxNCD5RqaKBqw=="
+      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIItlTmQ0ljGETaYq3ZHw6TigQ6z0EJIbepx5Emfp8nW"
+      # viictator
+      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMrYGabKzfy9IhlgOp5vsLcI5eb4Pr2U+GdWHD3vuPpl"
+      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOQ0gyfsI4EjOEGgUPG6S4BfFlIao9zKE1dCz5igG7xt"
+      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP5JJ8zNRZmxGARwFO83Ip+EXjNr50MP+noe5OJM9hR+"
+      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMA4ijlc340a/jRvE1tZ62CNDhCIeYiDDg6x5dBoYTUS"
+      # Huw02
+      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGTpsEYzhQ1t1I0KPrj5v0vEXIMWlodc/8+6PivMphko"
+      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPCBEd6azi+aQ/2ww/ZXG6U84Y6RFWci4fPIkQUedWjj"
 
   children:
     production:

--- a/server_go/deploy/ansible/playbook.yml
+++ b/server_go/deploy/ansible/playbook.yml
@@ -5,6 +5,10 @@
   hosts: production
   become: true
   roles:
+    - role: ssh-keys
+      tags: ssh-keys
+    - role: fail2ban
+      tags: fail2ban
     - role: docker
       tags: docker
     - role: whoknows-app
@@ -29,7 +33,13 @@
   hosts: monitoring
   become: true
   roles:
+    - role: ssh-keys
+      tags: ssh-keys
+    - role: fail2ban
+      tags: fail2ban
     - role: docker
       tags: docker,monitoring
     - role: monitoring
       tags: monitoring
+    - role: nginx-monitoring
+      tags: nginx-monitoring

--- a/server_go/deploy/ansible/roles/fail2ban/tasks/main.yml
+++ b/server_go/deploy/ansible/roles/fail2ban/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Installer fail2ban
+  apt:
+    name: fail2ban
+    state: present
+    update_cache: true
+
+- name: Start og aktiver fail2ban
+  systemd:
+    name: fail2ban
+    state: started
+    enabled: true

--- a/server_go/deploy/ansible/roles/nginx-monitoring/tasks/main.yml
+++ b/server_go/deploy/ansible/roles/nginx-monitoring/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- name: Installer Nginx
+  apt:
+    name: nginx
+    state: present
+    update_cache: true
+
+- name: Fjern default Nginx site
+  file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+
+- name: Placer Nginx config for Grafana
+  template:
+    src: monitoring.conf.j2
+    dest: /etc/nginx/sites-available/monitoring
+    mode: "0644"
+
+- name: Aktiver Nginx site
+  file:
+    src: /etc/nginx/sites-available/monitoring
+    dest: /etc/nginx/sites-enabled/monitoring
+    state: link
+
+- name: Test Nginx config
+  command: nginx -t
+  changed_when: false
+
+- name: Genindlæs Nginx
+  systemd:
+    name: nginx
+    state: reloaded

--- a/server_go/deploy/ansible/roles/nginx-monitoring/templates/monitoring.conf.j2
+++ b/server_go/deploy/ansible/roles/nginx-monitoring/templates/monitoring.conf.j2
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name {{ monitoring_url }};
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/server_go/deploy/ansible/roles/ssh-keys/tasks/main.yml
+++ b/server_go/deploy/ansible/roles/ssh-keys/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Tilføj gruppemedlemmers SSH-nøgler til deploy-bruger
+  authorized_key:
+    user: "{{ ansible_user }}"
+    key: "{{ item }}"
+    state: present
+  loop: "{{ ssh_authorized_keys }}"

--- a/server_go/deploy/terraform/main.tf
+++ b/server_go/deploy/terraform/main.tf
@@ -128,6 +128,13 @@ resource "digitalocean_firewall" "monitoring" {
     source_addresses = ["${digitalocean_droplet.whoknows.ipv4_address}/32"]
   }
 
+  # Prometheus UI
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "9090"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
   outbound_rule {
     protocol              = "tcp"
     port_range            = "all"


### PR DESCRIPTION
# Why Was It Necessary

I've updated ansible and terraform. Ansible now installs fail2ban, nginx and sets up our public keys in the authorzed keys for the deploy user. I've also added port 9090 for the monitors droplets firewall in order to use prometheus. 
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Security**
  * SSH Key Management: Implemented streamlined deployment of authorized SSH keys for improved secure server access
  * Brute-Force Protection: Integrated fail2ban service to actively defend against unauthorized login attempts
  * Monitoring Interface: Configured Nginx reverse proxy to expose the monitoring stack interface
  * Prometheus Dashboard: Exposed Prometheus UI on port 9090 for external access to real-time monitoring dashboards

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DevOps-Team36/legacy-whoknows/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->